### PR TITLE
Allow Preview of markdown message while editing

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require preview
 //= require_tree .

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,0 +1,30 @@
+$(function(){
+  var $message = $("#page_message");
+  var $previewBox = $(".preview-box");
+  var previewPlaceholder = $previewBox.html()
+
+  $message.keyup(function(){
+    delay(preview, 1000);
+  })
+
+  var delay = (function(){
+    var timer = 0;
+    return function(callback, ms){
+      clearTimeout(timer);
+      timer = setTimeout(callback, ms);
+    };
+  })();
+
+  var preview = function(){
+    var message = $message.val();
+    if (message) {
+      $.post("/previews", { preview: message }, displayMessage);
+    } else {
+      displayMessage(previewPlaceholder);
+    };
+  };
+
+  var displayMessage = function(text){
+    $previewBox.html(text);
+  };
+});

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,0 +1,12 @@
+class PreviewsController < ApplicationController
+  def create
+    @preview = MarkdownHelper.new(preview).render.to_json
+    render json: @preview
+  end
+
+  private
+
+  def preview
+    params.require(:preview)
+  end
+end

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -8,6 +8,10 @@
     label: "Your Message's Url: #{root_url}url-key-example"
   ) %>
   <%= f.input :message, placeholder: "your secret message here..." %>
+  <div class="preview-box">
+    <p>your secret message preview here...</p>
+  </div>
   <%= f.input :password %>
   <%= f.button :submit %>
 <% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   resources :secrets, as: :pages, controller: :pages, only: [:new, :create]
   get "/:url_key" => "permissions#new"
   resources :permissions, only: [:create]
+  resources :previews, only: [:create]
 end

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -9,7 +9,7 @@ feature "Visitor Creates a Secret" do
     click_button "Create"
 
     expect(page).to have_content("example")
-    expect(Page.count).to eq(1)
+    expect(Page.last.message).to eq("Stop Rebulba!")
   end
 
   scenario "page with errors" do

--- a/spec/features/view_markdown_preview_spec.rb
+++ b/spec/features/view_markdown_preview_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+feature "Visitor views markdown preview", js: true do
+  scenario "inserts link" do
+    visit new_page_path
+    fill_in "Message", with: "<a href='www.example.com'>example</a>"
+
+    expect(page).to have_link("example")
+  end
+end


### PR DESCRIPTION
The markdown javascript libraries do not parse with the same rules as
the redcarpet markdown gem. This leads to discrepancies between the
preview and the hidden page created.

The solution is to have an api for the message preview that is displayed
to the user while they edit the message. This could put heavy load on
the server (I paid for the cheapest option) so the JavaScript
`setTimeout` function is used. Users that stop typing for a second will
see the preview.
http://stackoverflow.com/questions/1909441/jquery-keyup-delay

One other feature spec modified so as not to depend on test order. Databasecleaner gem could have been used instead, but this seems easier. Instead of relying on `Page.count` to see if the page was created we just check the `page.message`