### PR TITLE
Emulate snapchat (then sell to Facebook)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.0)
     multi_json (1.11.2)
     neat (1.7.2)
@@ -157,8 +157,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     newrelic_rpm (3.12.1.298)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
     pg (0.18.2)
     pry (0.10.1)
@@ -333,4 +333,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/app/assets/javascripts/clear_location.js
+++ b/app/assets/javascripts/clear_location.js
@@ -1,3 +1,9 @@
 document.addEventListener("DOMContentLoaded", function(event) {
-  window.history.pushState("", "", "/")
+  window.history.pushState("", "", "/");
+
+  var redirect = function() {
+    window.location = "";
+  };
+
+  window.setTimeout(redirect, window.duration);
 });

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,6 +14,6 @@ class PagesController < ApplicationController
   end
 
   def page_params
-    params.require(:page).permit(:password, :message, :url_key)
+    params.require(:page).permit(:password, :message, :duration, :url_key)
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,5 @@
 class Page < ActiveRecord::Base
   has_secure_password validations: true
   validates_uniqueness_of :url_key, conditions: -> { where(seen: false) }
+  validates :duration, inclusion: { in: (1..10) }
 end

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -11,6 +11,7 @@
   <div class="preview-box">
     <p>your secret message preview here...</p>
   </div>
+  <%= f.input :duration, input_html: { value: 1, max: 10, min: 1 } %>
   <%= f.input :password %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,4 +1,7 @@
 <div class="secret-message">
   <%= MarkdownHelper.new(@page.message).render %>
 </div>
+<script>
+  window.duration = <%= @page.duration * 1000 %>;
+</script>
 <%= javascript_include_tag "clear_location" %>

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+open -a postgres
+bundle exec rails s

--- a/db/migrate/20160116201534_add_duration_to_pages.rb
+++ b/db/migrate/20160116201534_add_duration_to_pages.rb
@@ -1,0 +1,5 @@
+class AddDurationToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150718150850) do
+ActiveRecord::Schema.define(version: 20160116201534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20150718150850) do
     t.boolean  "seen",            default: false
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
+    t.integer  "duration"
   end
 
   add_index "pages", ["seen", "url_key"], name: "index_pages_on_seen_and_url_key", using: :btree

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     url_key "obscure"
     message "Defeat Rebulba"
     password "Password"
+    duration 3
   end
 end

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -5,6 +5,7 @@ feature "Visitor Creates a Secret" do
     visit new_page_path
     fill_in "Url", with: "example"
     fill_in "Message", with: "Stop Rebulba!"
+    fill_in "Duration", with: 3
     fill_in "Password", with: "Password"
     click_button "Create"
 

--- a/spec/features/visit_secret_page_spec.rb
+++ b/spec/features/visit_secret_page_spec.rb
@@ -42,6 +42,17 @@ feature "Visit Secret Page", js: true do
     expect(current_path).to eq("/")
   end
 
+  scenario "page vanishes" do
+    secret_page = create(:page, message: "Hi", duration: 2)
+
+    visit_and_authenticate_for(secret_page)
+
+    expect(page).to have_text("Hi")
+    sleep 2
+
+    expect(page).to_not have_text("Hi")
+  end
+
   def current_path
     URI.parse(current_url).path
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -15,5 +15,20 @@ RSpec.describe Page, :type => :model do
 
       expect(page).to be_valid
     end
+
+    describe "duration" do
+      it "cannot be outside the range of 1 and 10" do
+        page = build(:page, duration: 11)
+
+        expect(page).to_not be_valid
+        expect(page.errors[:duration]).to be_present
+      end
+
+      it "rounds to an integer" do
+        page = build(:page, duration: 1.5)
+
+        expect(page.duration).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
The page should disappear after 1 to 10 seconds. The user can specify
this in the first form. We use JS to change the window.location to the
root path.

Defining duration on window in erb template