### PR TITLE
Only require one field for page creation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //= require preview
 //= require url_key
 //= require toggle_password
+//= require toggle_options
 //= require giphy

--- a/app/assets/javascripts/toggle_options.js
+++ b/app/assets/javascripts/toggle_options.js
@@ -1,0 +1,9 @@
+$(function(){
+  var $button = $("#more-options");
+  var $optionalFieldWrap = $(".optional-fields");
+
+  $button.click(function(e){
+    e.preventDefault();
+    $optionalFieldWrap.toggle("hidden");
+  });
+});

--- a/app/assets/javascripts/toggle_password.js
+++ b/app/assets/javascripts/toggle_password.js
@@ -1,6 +1,6 @@
 $(function(){
   var $input = $("#page_require_password");
-  var $passwordWrap = $(".page_password");
+  var $passwordWrap = $(".page_password").hide();
 
   $input.change(function(){
     $passwordWrap.toggle();

--- a/app/assets/javascripts/url_key.js
+++ b/app/assets/javascripts/url_key.js
@@ -4,8 +4,9 @@ $(function(){
   var previewPlaceholder = $previewLabel.text();
 
   $input.keyup(function(){
-    var labelText = previewPlaceholder.split("url-key-example")[0];
-    var newText = labelText + $input.val();
+    var split = previewPlaceholder.split("/")
+    var oldText = split.slice(0, split.length - 1);
+    var newText = oldText.join("/") + "/" + $input.val();
     $previewLabel.text(newText);
   })
 });

--- a/app/assets/stylesheets/pages/page.scss
+++ b/app/assets/stylesheets/pages/page.scss
@@ -7,4 +7,8 @@
   .error {
     color: red;
   }
+
+  .hidden {
+    display: none;
+  }
 }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,9 +3,18 @@ class Page < ActiveRecord::Base
 
   validates :password_digest, presence: true, if: :require_password?
   validates :url_key, presence: true
+  validates :message, presence: true
   validates_uniqueness_of :url_key, conditions: -> { where(seen: false) }
   validates(
     :duration,
     inclusion: { in: (1..10), message: "Must be between 1 and 10 seconds" }
   )
+
+  after_initialize :set_random_url_key
+
+  private
+
+  def set_random_url_key
+    self.url_key = SecureRandom.hex(10) unless self.url_key.present?
+  end
 end

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -7,15 +7,20 @@
   <div class="preview-box">
     <p>your secret message preview here...</p>
   </div>
-  <%= f.input :duration, input_html: { value: 3, max: 10, min: 1 } %>
-  <%= f.input(
-    :url_key,
-    as: :string,
-    placeholder: "url-key-example",
-    label: "Your Message's Url: #{root_url}url-key-example"
-  ) %>
-  <%= f.input :require_password %>
-  <%= f.input :password %>
+
+  <div class="optional-fields hidden">
+    <%= f.input :duration, input_html: { value: 3, max: 10, min: 1 } %>
+    <%= f.input(
+      :url_key,
+      as: :string,
+      placeholder: "url-key-example",
+      label: "Specify url: #{root_url + @page.url_key}"
+    ) %>
+    <%= f.input :require_password %>
+    <%= f.input :password %>
+  </div>
+
   <%= f.button :submit %>
+  <button id="more-options">More Options</button>
 <% end %>
 

--- a/db/migrate/20160207235457_default_require_password_to_false.rb
+++ b/db/migrate/20160207235457_default_require_password_to_false.rb
@@ -1,0 +1,9 @@
+class DefaultRequirePasswordToFalse < ActiveRecord::Migration
+  def up
+    change_column_default :pages, :require_password, false
+  end
+
+  def down
+    change_column_default :pages, :require_password, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160121174252) do
+ActiveRecord::Schema.define(version: 20160207235457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20160121174252) do
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
     t.integer  "duration"
-    t.boolean  "require_password", default: true,  null: false
+    t.boolean  "require_password", default: false, null: false
   end
 
   add_index "pages", ["seen", "url_key"], name: "index_pages_on_seen_and_url_key", using: :btree

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :page do
-    url_key "obscure"
     message "Defeat Rebulba"
     password "Password"
     require_password true

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Visitor Creates a Secret" do
   scenario "no password" do
     visit new_page_path
-    fill_in "Url", with: "example"
+    fill_in "url", with: "example"
     fill_in "Message", with: "Stop Rebulba!"
     fill_in "Duration", with: 3
     uncheck "Require password"
@@ -16,7 +16,7 @@ feature "Visitor Creates a Secret" do
 
   scenario "custom url key" do
     visit new_page_path
-    fill_in "Url", with: "example"
+    fill_in "url", with: "example"
     fill_in "Message", with: "Stop Rebulba!"
     fill_in "Duration", with: 3
     fill_in "Password", with: "Password"

--- a/spec/features/view_markdown_preview_spec.rb
+++ b/spec/features/view_markdown_preview_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 feature "Visitor views markdown preview", js: true do
   scenario "inserts link" do
     visit new_page_path
+
     fill_in "Message", with: "<a href='www.example.com'>example</a>"
 
     expect(page).to have_link("example")
@@ -10,6 +11,8 @@ feature "Visitor views markdown preview", js: true do
 
   scenario "edits url_key" do
     visit new_page_path
+    click_button "More Options"
+
     fill_in "page_url_key", with: "test-it"
 
     expect(page).to have_text("test-it")

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 RSpec.describe Page, :type => :model do
   it { is_expected.to validate_presence_of(:url_key) }
 
+  describe "url_key initialization" do
+    it "has a random 20 character string if no value is specified" do
+      page = build(:page)
+
+      expect(page.url_key.length).to eq(20)
+    end
+  end
+
   describe "password validation" do
     it "validates password presence" do
       page = build(:page, password: nil, require_password: true)


### PR DESCRIPTION
This web application is becoming cluttered with features. Based on
observing users in the wild (and forcing people to use the app) it seems
most fun to send GIFs. Nobody cares too much about setting a url_key,
password protecting a page.

* Default url key is a string of characters (provides security by
  obscurity)
* Hides Duration field (already defaulted), and password field (default
  switched to false since nobody is actually passing secrets)

Next step: remove require password column and checkbox (optional
implied)