### PR TITLE
Use real giphy api key

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+GIPHY_API_KEY=dc6zaTOxFJmzC

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem "coffee-rails", "~> 4.1.0"
 gem "delayed_job_active_record"
 gem "email_validator"
 gem "flutie"
+
+gem "giphy"
+
 gem "high_voltage"
 gem "i18n-tasks"
 gem "jquery-rails"
@@ -51,6 +54,7 @@ group :test do
   gem "shoulda-matchers", require: false
   gem "simplecov", require: false
   gem "timecop"
+  gem "webmock"
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     colorize (0.7.7)
     columnize (0.9.0)
     concurrent-ruby (1.0.1)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     delayed_job (4.0.6)
@@ -117,13 +119,27 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.9.2)
+      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware-parse_oj (0.3.0)
+      faraday (~> 0.9.0)
+      faraday_middleware (~> 0.9.1)
+      oj (~> 2.0)
     flutie (2.0.0)
     formulaic (0.3.0)
       activesupport
       capybara
       i18n
+    giphy (3.0.0)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9)
+      faraday_middleware-parse_oj (~> 0.3)
+      launchy (~> 2.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    hashdiff (0.2.2)
     high_voltage (2.4.0)
     highline (1.7.2)
     i18n (0.7.0)
@@ -152,6 +168,7 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
@@ -162,6 +179,7 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
+    oj (2.14.3)
     pg (0.18.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -222,6 +240,7 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    safe_yaml (1.0.4)
     sass (3.4.16)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -280,6 +299,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (1.22.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -307,6 +330,7 @@ DEPENDENCIES
   factory_girl_rails
   flutie
   formulaic
+  giphy
   high_voltage
   i18n-tasks
   jquery-rails
@@ -334,6 +358,7 @@ DEPENDENCIES
   uglifier (>= 2.7.2)
   unicorn
   web-console
+  webmock
 
 BUNDLED WITH
    1.11.2

--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -1,112 +1,41 @@
 $(function(){
-  'use strict';
-  var PUBLIC_KEY = 'dc6zaTOxFJmzC';
-  var BASE_URL = '//api.giphy.com/v1/gifs/';
-  var ENDPOINT = 'search';
-  var LIMIT = 1;
-  var RATING = 'pg';
+  "use strict";
 
-  var $queryInput = $('.query');
-  var $resultWrapper = $('.result');
-  var $loader = $('.loader');
-  var $inputWrapper = $('.input-wrapper');
-  var $clear = $('.clear');
-  var $randomButton = $('.random');
-  var $useThisButton = $('.use');
-  var currentTimeout;
+  window.Secret = window.Secret || {};
 
+  var $resultBox = $(".result");
   var $message = $("#page_message");
+  var $useThisButton = $(".use");
 
-  var query = {
-    text: null,
-    offset: 0,
-    request: function request() {
-      return BASE_URL + ENDPOINT + '?q=' + this.text + '&limit=' + LIMIT + '&rating=' + RATING + '&offset=' + this.offset + '&api_key=' + PUBLIC_KEY;
-    },
-    fetch: function fetch(callback) {
-      $.getJSON(this.request()).success(function (data) {
-        var results = data.data;
-        if (results.length) {
-          var url = results[0].images.downsized.url;
-          callback(url);
-        } else {
-          callback('');
-        }
-      }).fail(function (error) {
-        console.log(error);
-      });
+  $(".gif_search").on("ajax:success", function(e, data){
+    $resultBox.css("height", 200);
+    window.Secret.data = data;
+    showNextImage();
+  });
+
+  $useThisButton.click(addCurrentImg);
+
+  function currentImg() {
+    if (window.Secret.data) {
+      return window.Secret.data[window.Secret.currentI];
+    } else {
+      return "";
     }
-  };
-
-  function buildImg(src) {
-    if (!src) {
-      srce = '//giphy.com/embed/xv3WUrBxWkUPC'
-    }
-
-    return '<img src="' + src + '" alt="gif" />';
   }
 
-  $clear.on('click', function (e) {
-    $queryInput.val('');
-    $inputWrapper.removeClass('active').addClass('empty');
-    $('.gif').addClass('hidden');
-    $loader.removeClass('done');
-    $randomButton.removeClass('active');
-  });
-  $randomButton.on('click', function (e) {
-    query.offset = Math.floor(Math.random() * 25);
-    query.fetch(function (url) {
-      if (url.length) {
-        $resultWrapper.html(buildImg(url));
-        $randomButton.addClass('active');
-        $message.trigger("keyup");
-      } else {
-        $resultWrapper.html('<p class="no-results hidden">No Results found for <strong>' + query.text + '</strong></p>');
-        $randomButton.removeClass('active');
-      }
-      $loader.addClass('done');
-      currentTimeout = setTimeout(function () {
-        $('.no-results').toggleClass('hidden');
-      }, 1000);
-    });
-  });
-
-  $queryInput.on('keyup', function (e) {
-    var key = e.which || e.keyCode;
-    query.text = $queryInput.val();
-    query.offset = Math.floor(Math.random() * 25);
-    if (currentTimeout) {
-      clearTimeout(currentTimeout);
-      $loader.removeClass('done');
+  function showNextImage() {
+    if (shouldResetCounter() || notInitialized() || lessThanTwoImages()) {
+      resetCounter(0);
+    } else {
+      incrementCounter(1);
     }
-    currentTimeout = setTimeout(function () {
-      currentTimeout = null;
-      $('.gif').addClass('hidden');
-      if (query.text && query.text.length) {
-        $inputWrapper.addClass('active').removeClass('empty');
-        query.fetch(function (url) {
-          if (url.length) {
-            $resultWrapper.html(buildImg(url));
-            $randomButton.addClass('active');
-          } else {
-            $resultWrapper.html('<p class="no-results hidden">No Results found for <strong>' + query.text + '</strong></p>');
-            $randomButton.removeClass('active');
-          }
-          $loader.addClass('done');
-          currentTimeout = setTimeout(function () {
-            $('.no-results').toggleClass('hidden');
-          }, 1000);
-        });
-      } else {
-        $inputWrapper.removeClass('active').addClass('empty');
-        $randomButton.removeClass('active');
-      }
-    }, 1000);
-  });
+    insertResults(buildImg(currentImg()));
+    window.setTimeout(showNextImage, 5000);
+  }
 
-  $useThisButton.click(function (e) {
+ function addCurrentImg(e) {
     e.preventDefault();
-    var url = $resultWrapper.children().attr("src");
+    var url = currentImg();
 
     if (!url) { return ; }
 
@@ -114,7 +43,35 @@ $(function(){
     var newValue = $message.val() + image;
     $message.val(newValue);
     $message.trigger("keyup");
-    $clear.trigger("click");
-    $resultWrapper.html("");
-  });
+ }
+
+  // helpers
+
+  function resetCounter(index) {
+    window.Secret.currentI = index;
+  }
+
+  function incrementCounter(increment) {
+    window.Secret.currentI = window.Secret.currentI + increment;
+  }
+
+  function shouldResetCounter() {
+    return window.Secret.currentI === window.Secret.data.length;
+  }
+
+  function lessThanTwoImages() {
+    return window.Secret.data.length < 2;
+  }
+
+  function notInitialized() {
+    return window.Secret.currentI === undefined;
+  }
+
+  function insertResults(result) {
+    $resultBox.html(result);
+  }
+
+  function buildImg(url) {
+    return "<img src='" + url + "'>";
+  }
 });

--- a/app/controllers/gif_searches_controller.rb
+++ b/app/controllers/gif_searches_controller.rb
@@ -1,0 +1,12 @@
+class GifSearchesController < ApplicationController
+  def create
+    @gif_search = GifSearch.new(search_params[:phrase])
+    render json: @gif_search.results.to_json, status: :ok
+  end
+
+  private
+
+  def search_params
+    params.require(:gif_search).permit(:phrase)
+  end
+end

--- a/app/models/gif_search.rb
+++ b/app/models/gif_search.rb
@@ -1,0 +1,21 @@
+class GifSearch
+  def initialize(phrase, options = {})
+    @phrase = phrase
+    @options = defaults.merge(options)
+  end
+
+  def results
+    response = Giphy.search(phrase, options)
+    response.map do |giphy_gif|
+      giphy_gif.fixed_height_image.url.to_s
+    end
+  end
+
+  private
+
+  attr_reader :phrase, :options
+
+  def defaults
+    { limit: 25, offset: 0 }
+  end
+end

--- a/app/views/pages/_giphy.html.erb
+++ b/app/views/pages/_giphy.html.erb
@@ -1,13 +1,6 @@
 <div id="giphy-page">
   <div class="row">
-    <div class="input-wrapper empty">
-      <input type="text" class="query" placeholder="Search GIFs..." />
-      <div class="loader"></div>
-      <div class="clear"></div>
-    </div>
-
     <button class="use">Add</button>
-    <button class="random">Search</button>
   </div>
 
   <div class="result">
@@ -15,3 +8,8 @@
     </p>
   </div>
 <div>
+
+<%= simple_form_for :gif_search, url: "/gif_searches", remote: true do |f| %>
+  <%= f.input :phrase %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/config/initializers/giphy.rb
+++ b/config/initializers/giphy.rb
@@ -1,0 +1,4 @@
+Giphy::Configuration.configure do |config|
+  config.version = "v1"
+  config.api_key = ENV.fetch("GIPHY_API_KEY")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   get "/:url_key" => "permissions#new"
   resources :permissions, only: [:create]
   resources :previews, only: [:create]
+
+  resources :gif_searches, only: [:create]
 end

--- a/spec/features/user_searches_gif_spec.rb
+++ b/spec/features/user_searches_gif_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+feature "User searches gif", js: true do
+  scenario do
+    stub_gif_search_results("dog.gif")
+
+    visit new_page_path
+    fill_in "Phrase", with: "dog"
+    click_button "Search"
+
+    expect(page).to have_xpath("//img[@src=\"dog.gif\"]")
+  end
+
+  def stub_gif_search_results(url)
+    stub_request(:any, %r{http:\/\/api.giphy.com}).
+      to_return(body: req_body(url))
+  end
+
+  def req_body(url)
+    {
+      "data": [
+        {
+          images: {
+            fixed_height: {
+              url: url,
+            }
+          }
+        },
+      ]
+    }.to_json
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"
+require "spec_helper"
 require "shoulda/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
@@ -21,3 +22,4 @@ end
 
 ActiveRecord::Migration.maintain_test_schema!
 Capybara.javascript_driver = :webkit
+Capybara::Webkit.configure(&:skip_image_loading)


### PR DESCRIPTION

Use real giphy api key
* The first step will towards using a real API key (the public one is
  rate limited) was moving most of the gif search logic server side
  The public key is currently still in use, but now it's in ENV
* Next step is to request a real key from giphy (might need to add
  something to the website like "powered by giphy" first.
* Now we automatically change gifs every 5 seconds--obnoxious? Maybe...

  Implementation

* In order to use a real giphy api key rather than the public one, the
  key must be stored server side (or anyone can use my key).
  Added initializer with giphy public key from
  https://github.com/Giphy/GiphyAPI fetched from ENV. Needed to provide
  api version.
* Adding public key to .env, and .env.test to allow travis to pass.