### PR TITLE
Small fixes to wording and functionality

### DIFF
--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -8,7 +8,12 @@ $(function(){
   var $useThisButton = $(".use");
 
   $(".gif_search").on("ajax:success", function(e, data){
+    if (!data.length) {
+      $resultBox.html("<p>No Results</p>");
+      return ;
+    }
     $resultBox.css("height", 200);
+    reset();
     window.Secret.data = data;
     showNextImage();
   });
@@ -30,7 +35,7 @@ $(function(){
       incrementCounter(1);
     }
     insertResults(buildImg(currentImg()));
-    window.setTimeout(showNextImage, 5000);
+    window.Secret.timeoutID = window.setTimeout(showNextImage, 5000);
   }
 
  function addCurrentImg(e) {
@@ -46,6 +51,11 @@ $(function(){
  }
 
   // helpers
+
+  function reset() {
+    window.clearTimeout(window.Secret.timeoutID);
+    window.Secret = {};
+  }
 
   function resetCounter(index) {
     window.Secret.currentI = index;

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -3,9 +3,9 @@
 <%= render partial: "giphy" %>
 
 <%= simple_form_for(@page) do |f| %>
-  <%= f.input :message, label: false, placeholder: "your secret note here..." %>
+  <%= f.input :message, label: false, placeholder: "your onetime note here..." %>
   <div class="preview-box">
-    <p>your secret note preview here...</p>
+    <p>your onetime note preview here...</p>
   </div>
 
   <div class="optional-fields hidden">


### PR DESCRIPTION
* Change "secret note" to "onetime note"
* The timeout is never cleared so gifs begin to change rapidly. This
  clears the timeout after each new array of gifs is returned. (clicking
  search multiple times would cause rapid changing in gifs)
* If no data is returned do not show results

Reset global state by resetting window.Secret

* This ensures clicking search again will not create issues with data
already present

To do

* Should prevent requesting same terms again
* implement some clientside caching of searched terms
* `window.Secret.searched`
* Find a way to click forwards and back or scroll through gifs
* Use setInterval rather than setTimeout