### PR TITLE
Add model spec for giphy search

### DIFF
--- a/spec/features/user_searches_gif_spec.rb
+++ b/spec/features/user_searches_gif_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "User searches gif", js: true do
+  include GiphyHelper
+
   scenario do
     stub_gif_search_results("dog.gif")
 
@@ -9,24 +11,5 @@ feature "User searches gif", js: true do
     click_button "Search"
 
     expect(page).to have_xpath("//img[@src=\"dog.gif\"]")
-  end
-
-  def stub_gif_search_results(url)
-    stub_request(:any, %r{http:\/\/api.giphy.com}).
-      to_return(body: req_body(url))
-  end
-
-  def req_body(url)
-    {
-      "data": [
-        {
-          images: {
-            fixed_height: {
-              url: url,
-            }
-          }
-        },
-      ]
-    }.to_json
   end
 end

--- a/spec/helpers/giphy_helper.rb
+++ b/spec/helpers/giphy_helper.rb
@@ -1,0 +1,20 @@
+module GiphyHelper
+  def stub_gif_search_results(url)
+    stub_request(:any, %r{http:\/\/api.giphy.com}).
+      to_return(body: response_body(url))
+  end
+
+  def response_body(url)
+    {
+      "data": [
+        {
+          images: {
+            fixed_height: {
+              url: url,
+            }
+          }
+        },
+      ]
+    }.to_json
+  end
+end

--- a/spec/models/gif_search_spec.rb
+++ b/spec/models/gif_search_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe GifSearch do
+  include GiphyHelper
+
+  describe "#results" do
+    it "returns an array of urls" do
+      stub_gif_search_results("dog")
+
+      search = GifSearch.new("dog")
+
+      expect(search.results.class).to eq(Array)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 require "spec_helper"
 require "shoulda/matchers"
+require "helpers/giphy_helper"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 


### PR DESCRIPTION
Before complicating the giphy search with more options and specialized
parsing, it will be nice to have a base spec and stub request methods in
a helper module to be shared amongst tests.