### PR TITLE
Resolves mixed content warnings (http/https)

### DIFF
--- a/app/models/gif_search.rb
+++ b/app/models/gif_search.rb
@@ -7,7 +7,7 @@ class GifSearch
   def results
     response = Giphy.search(phrase, options)
     response.map do |giphy_gif|
-      giphy_gif.fixed_height_image.url.to_s
+      extract_uri(giphy_gif).to_s
     end
   end
 
@@ -17,5 +17,11 @@ class GifSearch
 
   def defaults
     { limit: 25, offset: 0 }
+  end
+
+  def extract_uri(giphy_gif)
+    giphy_gif.fixed_height_image.url.tap do |uri|
+      uri.scheme = nil
+    end
   end
 end

--- a/spec/models/gif_search_spec.rb
+++ b/spec/models/gif_search_spec.rb
@@ -11,5 +11,16 @@ describe GifSearch do
 
       expect(search.results.class).to eq(Array)
     end
+
+    it "should return the url without the scheme" do
+      stub_gif_search_results(
+        "http://media2.giphy.com/media/Qw4X3Fr40xHU6E02khy/200.gif"
+      )
+
+      search = GifSearch.new("dog")
+
+      expect(search.results.first).
+        to eq("//media2.giphy.com/media/Qw4X3Fr40xHU6E02khy/200.gif")
+    end
   end
 end


### PR DESCRIPTION
* SSL cert purchased yesterday allows onetimenote to be served over
  https, but giphy was returning images served over http
* This uses relative path `//media1.giphy.com/image` in the clients
  browser since giphy allows images served over https as well
* A better alternative may be patching the giphy gem to make the request
  over https since they then return images served that way.