### PR TITLE
Whitelist html tags that can be used in notes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     rake (11.1.0)
     recipient_interceptor (0.1.2)
       mail
-    redcarpet (3.3.2)
+    redcarpet (3.3.4)
     refills (0.1.0)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)

--- a/app/models/markdown_helper.rb
+++ b/app/models/markdown_helper.rb
@@ -1,6 +1,8 @@
 require "redcarpet"
 
 class MarkdownHelper
+  include ActionView::Helpers::SanitizeHelper
+
   OPTIONS = {
     hard_wrap: true,
     autolink: true
@@ -12,6 +14,12 @@ class MarkdownHelper
 
   def render
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, OPTIONS)
-    markdown.render(@text).html_safe
+    markdown.render(sanitized_text).html_safe
+  end
+
+  private
+
+  def sanitized_text
+    sanitize(@text, tags: %w(a img h1 p br))
   end
 end

--- a/spec/models/markdown_helper_spec.rb
+++ b/spec/models/markdown_helper_spec.rb
@@ -4,7 +4,17 @@ RSpec.describe MarkdownHelper, :type => :model do
   describe "#render" do
     it "renders markdown" do
       helper = MarkdownHelper.new("Bullet")
+
       expect(helper.render).to eq("<p>Bullet</p>\n")
+    end
+
+    it "allows img tags but not scripts" do
+      helper = MarkdownHelper.new(
+        "<img src='link'>" + "<script>alert(\"xss!\")</script>"
+      )
+
+      expect(helper.render).to include("<img src=")
+      expect(helper.render).not_to include("<script>")
     end
   end
 end


### PR DESCRIPTION
* Mainly this is to avoid xss by preventing iframes/script tags
* Using rails sanitizer (possible performance downside over nokogiri or
  but this should be more robust)
* updating redcarpet