### PR TITLE
Prevent message from showing up in logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,5 +88,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
+  config.filter_parameters << :message
 end
 Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i


### PR DESCRIPTION
* This application could be used to send sensitive information. The
  message portion should not show up in application logs since that
  would leave a record the sensitive information.