### PR TITLE
Encrypt messages with password as the key

### DIFF
--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -17,6 +17,7 @@ class PermissionsController < ApplicationController
     @page = Page.find_by(url_key: url_key)
     permission = Permission.new(@page)
     if permission.grant_for?(page_password)
+      @page.password = page_password
       reveal(@page)
     else
       redirect_to :back

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,6 @@
 class Page < ActiveRecord::Base
-  attr_encrypted :message, key: ENV.fetch("SECRET_KEY_BASE")
+  attr_encrypted(:message, key: :encryption_key)
+
   has_secure_password validations: false
 
   validates :password_digest, presence: true, if: :require_password?
@@ -12,6 +13,16 @@ class Page < ActiveRecord::Base
   )
 
   after_initialize :set_random_url_key
+
+  def encryption_key
+    if require_password? && password
+      password + ENV.fetch("SECRET_KEY_BASE")
+    elsif password
+      self.require_password = true
+    else
+      ENV.fetch("SECRET_KEY_BASE")
+    end
+  end
 
   private
 

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :page do
-    message "Defeat Rebulba"
     password "Password"
     require_password true
     duration 3
+    message "Defeat Rebulba"
   end
 end

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -11,7 +11,10 @@ feature "Visitor Creates a Secret" do
     click_button "Create"
 
     expect(page).to have_content("example")
-    expect(Page.last.message).to eq("Stop Rebulba!")
+
+    click_link("here")
+    expect(page).to have_text("Stop Rebulba!")
+    expect(Page.count).to eq(0)
   end
 
   scenario "custom url key" do
@@ -19,12 +22,18 @@ feature "Visitor Creates a Secret" do
     fill_in "page_url_key", with: "example"
     fill_in "page_message", with: "Stop Rebulba!"
     fill_in "page_duration", with: 3
+    find(:css, "#page_require_password").click
+    find(:css, "#page_require_password").set(true)
     fill_in "page_password", with: "Password"
 
     click_button "Create"
 
     expect(page).to have_content("example")
-    expect(Page.last.message).to eq("Stop Rebulba!")
+
+    click_link("here")
+    fill_in "Password", with: "Password"
+    click_button "Submit"
+    expect(page).to have_content("Stop Rebulba!")
   end
 
   scenario "page with errors" do


### PR DESCRIPTION
* Currently messages without a password can be decrypted from the rails
  console. This is because the key used for encryption is a constant
  (it just uses a variable from the ENV, i.e. SECRET_KEY_BASE).
  Since the attr_encrypted gem allows the dynamic creation of a key, I
  can use the password as part of the key. Since passwords are encrypted
  and stored using a cryptographic hash, one cannot get the actual
  password key even with access to the rails console on the server. The
  messages created with a password are virtually impossible to read
  without knowing the original password used to create them.
* Also improves test coverage by testing whether a user can set up a
  page and then view that page (with and without a password)

* It may not be the best practice to use the SECRET_KEY_BASE for
  everything including as salt for when a user uses a password. This
  allows users to store short passwords rather than the 32 bits required
  by the gem.

* Noticed a small UI bug for when a user clicks "require password" and
  then makes a mistake in the form (leaves the body blank) then the
  toggle for showing the password field is off

* Factory order of traits matters: the message must come after the
  password traits or else the key will not use the password for
  encryption.
* The third conditional under encryption_key method is a hack to ensure
  that if the password field is filled out, the password is used to
  encrypt even if the require_password box is not checked.

* Simplify later, possibly remove require_password column