### PR TITLE
Remove require_password field

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,7 +16,6 @@
 //= require textarea
 //= require preview
 //= require url_key
-//= require toggle_password
 //= require toggle_options
 //= require giphy
 //= require search_input

--- a/app/assets/javascripts/toggle_password.js
+++ b/app/assets/javascripts/toggle_password.js
@@ -1,8 +1,0 @@
-$(function(){
-  var $input = $("#page_require_password");
-  var $passwordWrap = $(".page_password").hide();
-
-  $input.change(function(){
-    $passwordWrap.toggle();
-  });
-});

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,6 @@ class PagesController < ApplicationController
       :duration,
       :message,
       :password,
-      :require_password,
       :url_key
     )
   end

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -4,7 +4,7 @@ class PermissionsController < ApplicationController
   def new
     @page = Page.find_by!(url_key: params[:url_key])
 
-    if @page.require_password?
+    if @page.password_digest
       render "new"
     elsif bot?
       render "pages/bot"

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,6 @@ class Page < ActiveRecord::Base
 
   has_secure_password validations: false
 
-  validates :password_digest, presence: true, if: :require_password?
   validates :url_key, presence: true
   validates :message, presence: true
   validates_uniqueness_of :url_key
@@ -15,10 +14,8 @@ class Page < ActiveRecord::Base
   after_initialize :set_random_url_key
 
   def encryption_key
-    if require_password? && password
+    if password
       password + ENV.fetch("SECRET_KEY_BASE")
-    elsif password
-      self.require_password = true
     else
       ENV.fetch("SECRET_KEY_BASE")
     end

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -16,7 +16,6 @@
       placeholder: "url-key-example",
       label: "Specify url: #{root_url + @page.url_key}"
     ) %>
-    <%= f.input :require_password %>
     <%= f.input :password %>
   </div>
 

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :page do
     password "Password"
-    require_password true
     duration 3
     message "Defeat Rebulba"
   end

--- a/spec/features/bot_visits_secret_page_spec.rb
+++ b/spec/features/bot_visits_secret_page_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "Bot visits secret page", js: true do
   scenario "no password required" do
     stub_browser_as_bot(true)
-    secret_page = create(:page, password: nil, require_password: false)
+    secret_page = create(:page, password: nil)
 
     visit "/#{secret_page.url_key}"
 

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -6,7 +6,6 @@ feature "Visitor Creates a Secret" do
     fill_in "page_url_key", with: "example"
     fill_in "page_message", with: "Stop Rebulba!"
     fill_in "page_duration", with: 3
-    uncheck "Require password"
 
     click_button "Create"
 
@@ -17,13 +16,11 @@ feature "Visitor Creates a Secret" do
     expect(Page.count).to eq(0)
   end
 
-  scenario "custom url key" do
+  scenario "custom url key and password" do
     visit new_page_path
     fill_in "page_url_key", with: "example"
     fill_in "page_message", with: "Stop Rebulba!"
     fill_in "page_duration", with: 3
-    find(:css, "#page_require_password").click
-    find(:css, "#page_require_password").set(true)
     fill_in "page_password", with: "Password"
 
     click_button "Create"

--- a/spec/features/visit_secret_page_spec.rb
+++ b/spec/features/visit_secret_page_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 feature "Visit Secret Page", js: true do
   scenario "no password required" do
-    secret_page = create(:page, password: nil, require_password: false)
+    secret_page = create(:page, password: nil)
 
     visit "/#{secret_page.url_key}"
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -12,21 +12,6 @@ RSpec.describe Page, :type => :model do
     end
   end
 
-  describe "password validation" do
-    it "validates password presence" do
-      page = build(:page, password: nil, require_password: true)
-
-      expect(page).not_to be_valid
-      expect(page.errors[:password_digest]).to be_present
-    end
-
-    it "does not validate password if a password is not required" do
-      page = build(:page, password: nil, require_password: false)
-
-      expect(page).to be_valid
-    end
-  end
-
   describe "duration" do
     it "cannot be outside the range of 1 and 10" do
       page = build(:page, duration: 11)


### PR DESCRIPTION
* This field is not necessary since the presence of a password or
  encrypted password can be checked instead.
* The field is left blank by default
* The js toggling was certainly annoying and left room for bugs.
* The column can be removed in a separate migration (along with the
  message column)