### PR TITLE
Remove unused columns

### DIFF
--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -3,7 +3,12 @@
 <%= render partial: "giphy" %>
 
 <%= simple_form_for(@page) do |f| %>
-  <%= f.input :message, label: false, placeholder: "your onetime note here..." %>
+  <%= f.input(
+    :message,
+    label: false,
+    placeholder: "your onetime note here...",
+    as: :text
+  ) %>
   <div class="preview-box">
     <p>your onetime note preview here...</p>
   </div>

--- a/db/migrate/20160828133604_remove_message_and_require_password_from_pages.rb
+++ b/db/migrate/20160828133604_remove_message_and_require_password_from_pages.rb
@@ -1,0 +1,6 @@
+class RemoveMessageAndRequirePasswordFromPages < ActiveRecord::Migration
+  def change
+    remove_column :pages, :require_password, :boolean
+    remove_column :pages, :message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,19 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160820162417) do
+ActiveRecord::Schema.define(version: 20160828133604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "pages", force: :cascade do |t|
     t.string   "url_key"
-    t.text     "message",              default: "",    null: false
     t.string   "password_digest"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.integer  "duration"
-    t.boolean  "require_password",     default: false, null: false
     t.text     "encrypted_message"
     t.text     "encrypted_message_iv"
   end


### PR DESCRIPTION
* Messages are encrypted so the regular `message` column is unused
* Reliance on the require_password field was removed in the previous
  commit
* There are no messages old enough in production to require these
  columns