### PR TITLE
Generate url_key before save

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,7 +3,6 @@ class Page < ActiveRecord::Base
 
   has_secure_password validations: false
 
-  validates :url_key, presence: true
   validates :message, presence: true
   validates_uniqueness_of :url_key
   validates(
@@ -11,7 +10,7 @@ class Page < ActiveRecord::Base
     inclusion: { in: (1..10), message: "Must be between 1 and 10 seconds" }
   )
 
-  after_initialize :set_random_url_key
+  before_save :set_random_url_key
 
   def encryption_key
     if password

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -18,8 +18,8 @@
     <%= f.input(
       :url_key,
       as: :string,
-      placeholder: "url-key-example",
-      label: "Specify url: #{root_url + @page.url_key}"
+      placeholder: "example",
+      label: "Specify url: #{root_url + "example"}"
     ) %>
     <%= f.input :password %>
   </div>

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -16,16 +16,16 @@ feature "Visitor Creates a Secret" do
     expect(Page.count).to eq(0)
   end
 
-  scenario "custom url key and password" do
+  scenario "no url_key" do
     visit new_page_path
-    fill_in "page_url_key", with: "example"
+
+    expect(page).to have_text(root_path + "example")
+
     fill_in "page_message", with: "Stop Rebulba!"
     fill_in "page_duration", with: 3
     fill_in "page_password", with: "Password"
 
     click_button "Create"
-
-    expect(page).to have_content("example")
 
     click_link("here")
     fill_in "Password", with: "Password"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Page, :type => :model do
-  it { is_expected.to validate_presence_of(:url_key) }
   it { is_expected.to validate_uniqueness_of(:url_key) }
 
   describe "url_key initialization" do
-    it "has a random 20 character string if no value is specified" do
-      page = build(:page)
+    it "sets a random 10 digit url key if none exist" do
+      page = build(:page, url_key: nil)
+      page.save!
 
       expect(page.url_key.length).to eq(10)
     end


### PR DESCRIPTION
* The url_key was originally generated as a random string of characters
  and appears in the form. That field will be left blank now, but a
  random url_key will be generated if the user does not fill that part
  out. A user probably does not need to see an example of a link first.
* This makes the root page static. Previously server side logic was
  needed to generate this root page because the url_key would have to be
  different and random each time. Now the page can be cached.