### PR TITLE
Better mobile image adding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-rails"
   gem "rspec-rails"
+  gem "teaspoon-jasmine"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,10 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    teaspoon (1.1.5)
+      railties (>= 3.2.5, < 6)
+    teaspoon-jasmine (2.3.4)
+      teaspoon (>= 1.0.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     terminal-table (1.5.2)
@@ -376,6 +380,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-commands-rspec
+  teaspoon-jasmine
   thin
   timecop
   title

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,4 @@ if defined? RSpec
 end
 
 task default: "bundler:audit"
+task default: "teaspoon"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,3 +20,4 @@
 //= require giphy
 //= require search_input
 //= require image_adder
+//= require insert_image_tags

--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -92,7 +92,17 @@ $(function(){
     return "<img src='" + url + "'>";
   }
 
+  function insertImgTags(message, imageMap) {
+    imageMap.forEach(function(url, index){
+      var key = "imgkey" + index;
+      var imgTag = Functions.buildImgTag(url);
+      message = message.replace(key, imgTag);
+    });
+    return message;
+  }
+
   window.Functions = {};
   window.Functions.currentImg = currentImg;
   window.Functions.buildImgTag = buildImgTag;
+  window.Functions.insertImgTags = insertImgTags;
 });

--- a/app/assets/javascripts/image_adder.js
+++ b/app/assets/javascripts/image_adder.js
@@ -9,17 +9,23 @@ $(function(){
 
     function initialize() {
       $useThisButton.click(addCurrentImg);
+      this.imageMap = [];
     }
 
     function addCurrentImg(e) {
       e.preventDefault();
       var imageUrl = Functions.currentImg();
-      var newValue = $message.val() + Functions.buildImgTag(imageUrl);
+      var newValue = $message.val() + addImgShortcut(imageUrl);
       $message.val(newValue);
       $message.trigger("keyup");
       $htmlBody.animate({
         scrollTop: $message.offset().top
       }, 1000);
+    }
+
+    function addImgShortcut(imageUrl) {
+      imageAdder.imageMap.push(imageUrl);
+      return " imgkey" + (imageAdder.imageMap.length -1) + " ";
     }
 
     return {

--- a/app/assets/javascripts/insert_image_tags.js
+++ b/app/assets/javascripts/insert_image_tags.js
@@ -1,0 +1,9 @@
+$(function(){
+  var $pageMessage = $("#page_message");
+
+  $("#new_page").submit(function(){
+    var messageText = $pageMessage.val();
+    var newVal = Functions.insertImgTags(messageText, imageAdder.imageMap);
+    $pageMessage.val(newVal);
+  });
+});

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -18,7 +18,8 @@ $(function(){
   var preview = function(){
     var message = $message.val();
     if (message) {
-      $.post("/previews", { preview: message }, displayMessage);
+      var finalMessage = Functions.insertImgTags(message, imageAdder.imageMap);
+      $.post("/previews", { preview: finalMessage }, displayMessage);
     } else {
       displayMessage(previewPlaceholder);
     };

--- a/spec/javascripts/giphy_spec.js
+++ b/spec/javascripts/giphy_spec.js
@@ -1,0 +1,24 @@
+//= require giphy
+
+describe("Giphy", function() {
+  describe("insertImgTags", function() {
+    it("replaces keys with image tags", function() {
+      var message = "imgkey0 cat!";
+      var imageMap = ["caturl.gif"];
+
+      var result = Functions.insertImgTags(message, imageMap);
+
+      var finalMessage = "<img src='caturl.gif'> cat!";
+      expect(result).toEqual(finalMessage);
+    });
+
+    it("does not affect a message without image keys", function() {
+      var message = "Hi cat!";
+      var imageMap = ["caturl.gif"];
+
+      var result = Functions.insertImgTags(message, imageMap);
+
+      expect(result).toEqual(message);
+    });
+  });
+});

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,0 +1,1 @@
+//= require jquery

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -1,0 +1,14 @@
+Teaspoon.configure do |config|
+  config.mount_at = "/jasmine"
+  config.root = nil
+  config.asset_paths = ["spec/javascripts", "spec/javascripts/stylesheets"]
+  config.fixture_paths = ["spec/javascripts/fixtures"]
+
+  config.suite do |suite|
+    suite.use_framework :jasmine, "2.3.4"
+    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.js"
+    suite.helper = "spec_helper"
+    suite.boot_partial = "boot"
+    suite.body_partial = "body"
+  end
+end


### PR DESCRIPTION
Why is this change necessary?
* Creating secret pages on mobile can be painful when an image tag needs
  to be moved or deleted. The tags are very long and the text is hard to
  select.
* This change allows image tags to be moved easily on small devices.

How does this accomplish the change?
* Instead of the markup tags for images/gifs being inserted into the
  message field, a key is generated in the format `imgkey0`. The number
  on the end is an index of an array that has the image src strings
  stored to be decoded on preview or submission of the form.
* Using letters/numbers but no special characters (e.g. `<imgkey1>`)
  makes it easier to copy and paste on a cell phone (at least my
  iPhone4s)

* Spaces are inserted around the key since this ensures two image keys
  are not next to each other. That would make them harder to select
  individually, although the parsing would still work.
* A javascript testing framework is added since this application is
  becoming javascript heavy.