### PR TITLE
URI encode url key in preview

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,12 +1,6 @@
 # See https://houndci.com/configuration for help.
-coffeescript:
-  # config_file: .coffeescript-style.json
-  enabled: true
-haml:
-  # config_file: .haml-style.yml
-  enabled: true
 javascript:
-  # config_file: .javascript-style.json
+  config_file: .javascript-style.json
   enabled: true
   # ignore_file: .javascript_ignore
 ruby:

--- a/.javascript-style.json
+++ b/.javascript-style.json
@@ -1,0 +1,33 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 80,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "$",
+    "jQuery",
+    "jasmine",
+    "beforeEach",
+    "describe",
+    "expect",
+    "it",
+    "angular",
+    "inject",
+    "module",
+    "Functions"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true,
+  "eqnull": true
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require functions
 //= require jquery
 //= require jquery_ujs
 //= require jquery.autosize

--- a/app/assets/javascripts/functions.js
+++ b/app/assets/javascripts/functions.js
@@ -1,0 +1,3 @@
+(function(){
+  window.Functions = {};
+})();

--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -101,7 +101,6 @@ $(function(){
     return message;
   }
 
-  window.Functions = {};
   window.Functions.currentImg = currentImg;
   window.Functions.buildImgTag = buildImgTag;
   window.Functions.insertImgTags = insertImgTags;

--- a/app/assets/javascripts/url_key.js
+++ b/app/assets/javascripts/url_key.js
@@ -3,10 +3,14 @@ $(function(){
   var $previewLabel = $(".page_url_key label");
   var previewPlaceholder = $previewLabel.text();
 
-  $input.keyup(function(){
-    var split = previewPlaceholder.split("/")
+  Functions.modifyLabelText = function modifyLabelText(currentText, urlKey) {
+    var split = currentText.split("/");
     var oldText = split.slice(0, split.length - 1);
-    var newText = oldText.join("/") + "/" + $input.val();
-    $previewLabel.text(newText);
-  })
+    return oldText.join("/") + "/" + encodeURI(urlKey);
+  };
+
+  $input.keyup(function(){
+    var labelText = Functions.modifyLabelText(previewPlaceholder, $input.val());
+    $previewLabel.text(labelText);
+  });
 });

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,1 +1,2 @@
+//= require functions
 //= require jquery

--- a/spec/javascripts/url_key_spec.js
+++ b/spec/javascripts/url_key_spec.js
@@ -1,0 +1,25 @@
+//= require url_key
+
+describe("Url Key", function() {
+  describe("modifyLabelText", function() {
+    it("finds a url and swaps in a urlKey", function() {
+      var currentText = "Specify url: http://onetimenote.com/example";
+      var urlKey = "my-page";
+
+      var result = Functions.modifyLabelText(currentText, urlKey);
+
+      var expectedResult = "Specify url: http://onetimenote.com/my-page";
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("URI encodes spaces", function() {
+      var currentText = "Specify url: http://onetimenote.com/example";
+      var urlKey = "in between";
+
+      var result = Functions.modifyLabelText(currentText, urlKey);
+
+      var expectedResult = "Specify url: http://onetimenote.com/in%20between";
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
    URI encode url key in preview
    
    * The url ends up URI encoding so words separated by spaces will not end
      up in the final url. This is confusing since the url_key preview shows
      spaces. The `here` link is correct, but the text is not exactly
      accurate since urls can never have spaces.
    * This was a chance to add more isolated javascript specs. Right now to
      access a function in a javascript spec we namespace it inside
      `window.Functions`. This has been moved to it's own file and loaded
      first.
    * Adding hound defaults to `.javascript-style.json` so that `Functions`
      can be added to the predefined list.