### PR TITLE
Refactor gif

### DIFF
--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -27,11 +27,6 @@ $(function(){
 
   // helpers
 
-  function insertCurrentImgAndIncrement() {
-    insertCurrentImg();
-    counter.counterStep(1);
-  }
-
   function insertCurrentImg() {
     $resultBox.html(buildImgTag(counter.currentImg()));
   }

--- a/app/models/markdown_helper.rb
+++ b/app/models/markdown_helper.rb
@@ -9,17 +9,28 @@ class MarkdownHelper
   }
 
   def initialize(text)
-    @text = text
+    @text = replace_newlines(text)
   end
 
   def render
-    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, OPTIONS)
-    markdown.render(sanitized_text).html_safe
+    markdown.html_safe
   end
 
   private
 
+  def markdown
+    markdown_generator.render(sanitized_text)
+  end
+
+  def markdown_generator
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML, OPTIONS)
+  end
+
   def sanitized_text
     sanitize(@text, tags: %w(a img h1 p br))
+  end
+
+  def replace_newlines(text)
+    text.gsub("\n", "\n\n")
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Rails.application.configure do
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
+  config.filter_parameters += [:message, :preview]
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password, :message, :preview]
+Rails.application.config.filter_parameters += [:password]

--- a/spec/models/markdown_helper_spec.rb
+++ b/spec/models/markdown_helper_spec.rb
@@ -16,5 +16,11 @@ RSpec.describe MarkdownHelper, :type => :model do
       expect(helper.render).to include("<img src=")
       expect(helper.render).not_to include("<script>")
     end
+
+    it "handles single newlines with <p> tags" do
+      helper = MarkdownHelper.new("line1\nline2")
+
+      expect(helper.render).to eq("<p>line1</p>\n\n<p>line2</p>\n")
+    end
   end
 end


### PR DESCRIPTION
Newlines should not be ignored in markdown
* This ensures that hitting the enter key in the message textarea will
  actually create a line break. Previously, one would need to press
  enter twice, creating two line breaks to actually make a linebreak
  show up in the final message.
* This ensures a one to one mapping of line breaks, which is certainly
  more intuitive. Inserting the extra newline causes the markdown
  renderer to insert the tag. This is simpler than gsubbing in html tags
  in the Markdown helper class
* To debug messages/previews it is helpful to not filter these params in
  development or test so this change is left in.

* Also removes unused js function
