### PR TITLE
Ensure form has random url_key present

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,6 +3,7 @@ class Page < ActiveRecord::Base
 
   has_secure_password validations: false
 
+  validates :url_key, presence: true
   validates :message, presence: true
   validates_uniqueness_of :url_key
   validates(
@@ -10,7 +11,7 @@ class Page < ActiveRecord::Base
     inclusion: { in: (1..10), message: "Must be between 1 and 10 seconds" }
   )
 
-  before_save :set_random_url_key
+  after_initialize :set_random_url_key
 
   def encryption_key
     if password

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -18,8 +18,8 @@
     <%= f.input(
       :url_key,
       as: :string,
-      placeholder: "example",
-      label: "Specify url: #{root_url + "example"}"
+      placeholder: "url-key-example",
+      label: "Specify url: #{root_url + @page.url_key}"
     ) %>
     <%= f.input :password %>
   </div>

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -16,16 +16,16 @@ feature "Visitor Creates a Secret" do
     expect(Page.count).to eq(0)
   end
 
-  scenario "no url_key" do
+  scenario "custom url key and password" do
     visit new_page_path
-
-    expect(page).to have_text(root_path + "example")
-
+    fill_in "page_url_key", with: "example"
     fill_in "page_message", with: "Stop Rebulba!"
     fill_in "page_duration", with: 3
     fill_in "page_password", with: "Password"
 
     click_button "Create"
+
+    expect(page).to have_content("example")
 
     click_link("here")
     fill_in "Password", with: "Password"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -8,9 +8,8 @@ describe Page do
   end
 
   describe "url_key initialization" do
-    it "sets a random 10 digit url key if none exist" do
-      page = build(:page, url_key: nil)
-      page.save!
+    it "has a random 20 character string if no value is specified" do
+      page = build(:page)
 
       expect(page.url_key.length).to eq(10)
     end


### PR DESCRIPTION
* this was changed in a previous commit to be a blank field. If it was
left blank then a random key would be generated. However this also
allows refreshing the page after form submission and a user could
accidentally create multiple versions of their secret page. This is not
ideal.
* instead they will be navigated back to the original page.
* Unfortunately the error is on an option field so the user cannot see
it. I should probably follow up and ensure the fields are revealed if
they have errors present.
Revert "Generate url_key before save"

This reverts commit d393c25b6d516e804bea72043f295dc0f0a5919e.