### PR TITLE
Ensure fields with errors are always visible

### DIFF
--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -13,7 +13,7 @@
     <p>your onetime note preview here...</p>
   </div>
 
-  <div class="optional-fields hidden">
+  <div class="optional-fields <%= "hidden" unless @page.errors.present? %>">
     <%= f.input :duration, input_html: { value: 7, max: 10, min: 1 } %>
     <%= f.input(
       :url_key,

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -39,4 +39,15 @@ feature "Visitor Creates a Secret" do
 
     expect(page).to have_content("can't be blank")
   end
+
+  scenario "page with errors on optional field" do
+    create(:page, url_key: "taken")
+    visit new_page_path
+    fill_in "page_message", with: "blah"
+    fill_in "page_url_key", with: "taken"
+
+    click_button "Create"
+
+    expect(page).to have_text("has already been taken")
+  end
 end


### PR DESCRIPTION
* If the form has errors on the additional options (like url key) these
are not shown to the user without clicking the "More options" button.
* This came to light with the last commit that intentionally prevented
resubmitting the same form twice (where a url_key would have been
dynamically created if that field were left blank).