### PR TITLE
Display optional fields when errors are present

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,10 @@
 class PagesController < ApplicationController
   def new
-    @page = Page.new
+    @page = PagePresenter.new(Page.new)
   end
 
   def create
-    @page = Page.new(page_params)
+    @page = PagePresenter.new(Page.new(page_params))
 
     if @page.save
       render :success

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class PagePresenter < SimpleDelegator
+  OPTIONAL_FIELDS = [:url_key, :password, :duration].freeze
+
+  def optional_fields_state
+    if optional_fields_errors?
+      ""
+    else
+      "hidden"
+    end
+  end
+
+  private
+
+  def optional_fields_errors?
+    errors.any? { |field| OPTIONAL_FIELDS.include?(field) }
+  end
+end

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -13,7 +13,7 @@
     <p>your onetime note preview here...</p>
   </div>
 
-  <div class="optional-fields <%= "hidden" unless @page.errors.present? %>">
+  <div class="optional-fields <%= @page.optional_fields_state %>">
     <%= f.input :duration, input_html: { value: 7, max: 10, min: 1 } %>
     <%= f.input(
       :url_key,

--- a/spec/presenters/page_presenter_spec.rb
+++ b/spec/presenters/page_presenter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe PagePresenter do
+  describe "#optional_fields_state" do
+    it "returns 'hidden' if no errors are present" do
+      page_presenter = PagePresenter.new(build(:page))
+
+      expect(page_presenter.optional_fields_state).to eq("hidden")
+    end
+
+    it "returns '' when optional fields have errors" do
+      create(:page, url_key: "taken")
+
+      page = build(:page, url_key: "taken")
+      expect(page).not_to be_valid
+
+      page_presenter = PagePresenter.new(page)
+
+      expect(page_presenter.optional_fields_state).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
The problem:
* Optional fields are hidden by default to make creating a note simpler.
However, if the user clicks more options, and then modifies these fields
but provides invalid input, it can be hard to see the errors after form
submission.
* Previously one would have to click the "more options" button again to
see errors for a duration outside the time limit, or an already taken
url_key.

The change:
* The hidden element that wraps these fields now has a dynamically
generated css class: "hidden or ""
* This ensures the initial state of these fields is visible if there are
errors on them. If there are no errors, the default is to have a
"hidden" class.

Implementation:
* This mix of presentation logic and error state seemed best outside of
the ActiveRecord model. A presenter is introduced and tested here.
Hidden fields are denoted in a class constant defined in the
PagePresenter.

A funny note on Big O:
* Doing an `any?` inside an `include?` may look suboptimal for
performance (n^2 for worst case) compared to set operators like `&`
http://ruby-doc.org/stdlib-2.3.3/libdoc/set/rdoc/Set.html#method-i-26
But when each array has under 5 max elements the overhead for the set
operators is way too large.