### PR TITLE
Refactor Preview and timer into separate objects

### DIFF
--- a/.javascript-style.json
+++ b/.javascript-style.json
@@ -27,7 +27,11 @@
     "Counter",
     "counter",
     "ImageAdder",
-    "imageAdder"
+    "imageAdder",
+    "Preview",
+    "preview",
+    "afterEach",
+    "beforeEach"
   ],
   "quotmark": true,
   "trailing": true,

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require jquery.autosize
 //= require textarea
 //= require preview
+//= require preview_timer
 //= require url_key
 //= require toggle_options
 //= require counter

--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,31 +1,31 @@
 $(function(){
-  var $message = $("#page_message");
-  var $previewBox = $(".preview-box");
-  var previewPlaceholder = $previewBox.html()
-
-  $message.keyup(function(){
-    delay(preview, 1000);
-  })
-
-  var delay = (function(){
-    var timer = 0;
-    return function(callback, ms){
-      clearTimeout(timer);
-      timer = setTimeout(callback, ms);
-    };
-  })();
-
-  var preview = function(){
-    var message = $message.val();
-    if (message) {
-      var finalMessage = Functions.insertImgTags(message, imageAdder.imageMap);
-      $.post("/previews", { preview: finalMessage }, displayMessage);
-    } else {
-      displayMessage(previewPlaceholder);
-    };
+  var Preview = function Preview() {
+    this.$message = $("#page_message");
+    this.$previewBox = $(".preview-box");
+    this.previewPlaceholder = this.$previewBox.html();
   };
 
-  var displayMessage = function(text){
-    $previewBox.html(text);
+  Preview.prototype = {
+    createPreview: function createPreview(){
+      var message = this.$message.val();
+      if (message) {
+        $.post(
+          "/previews",
+          { preview: this.finalMessage(message) },
+          this.displayMessage.bind(this)
+        );
+      } else {
+        this.displayMessage.bind(this)(this.previewPlaceholder);
+      }
+    },
+    finalMessage: function(message){
+      return Functions.insertImgTags(message, imageAdder.imageMap);
+    },
+    displayMessage: function(text){
+      this.$previewBox.html(text);
+    }
   };
+
+  window.Preview = Preview;
+  window.preview = new Preview();
 });

--- a/app/assets/javascripts/preview_timer.js
+++ b/app/assets/javascripts/preview_timer.js
@@ -1,0 +1,19 @@
+$(function(){
+  var $message = $("#page_message");
+
+  var delay = (function(){
+    var timer = 0;
+    return function(callback, ms){
+      clearTimeout(timer);
+      timer = setTimeout(callback, ms);
+    };
+  })();
+
+  var preview = function(){
+    window.preview.createPreview();
+  };
+
+  $message.keyup(function(){
+    delay(preview, 1000);
+  });
+});

--- a/spec/javascripts/preview_spec.js
+++ b/spec/javascripts/preview_spec.js
@@ -1,0 +1,20 @@
+//= require preview
+
+$(function(){
+  describe("Preview", function() {
+    describe("createPreview", function() {
+      it("displays default text if box is empty", function() {
+        var $pageMessage = $("<textarea id='page_message'></textarea>");
+        var $previewBox = $("<div class='preview-box'>Default Text!</div>");
+        $("body").append($pageMessage).append($previewBox);
+
+        var preview = new Preview();
+        preview.createPreview();
+
+        var currentPreviewText = $previewBox.html();
+        expect(currentPreviewText).toEqual("Default Text!");
+      });
+    });
+  });
+});
+

--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -1,2 +1,3 @@
 //= require functions
 //= require jquery
+//= require support/cleanup

--- a/spec/javascripts/support/cleanup.js
+++ b/spec/javascripts/support/cleanup.js
@@ -1,0 +1,3 @@
+afterEach(function() {
+  $("body").html("");
+});


### PR DESCRIPTION
* The live preview uses a timer that generates a preview after every
keystroke followed by a one second delay.

* This change separates the delay logic and the preview generating logic
into separate objects. This allows for easier testing (a simple spec is
added for the preview functionality). The separate logic and testing may
be helpful for making the preview only appear when a button is pressed.
This saves many AJAX requests, reduces elements on the page that would
confuse a user, and matches the way Github allows markdown to be
previewed. This would requires some redesigning of this website.

Details:
* Some functions are broken down into smaller helper functions: e.g.
finalMessage. This preference for function over variable assignment can
help keep functions responsible for discreet bits of logic.
* A support/cleanup file is added to clear the html after each test.
This would cause duplicated page elements. I prefer to create the
elements used by the test at the top of each test file since this shows
clearly what needs to be on the page.

Later:
May follow up with stubbing some AJAX requests in the preview spec:
* https://github.com/jasmine/jasmine-ajax
* https://github.com/joneath/jasmine-ajax-mock