### PR TITLE
Ui improvement and refactor

### DIFF
--- a/app/assets/javascripts/counter.js
+++ b/app/assets/javascripts/counter.js
@@ -1,9 +1,8 @@
 $(function(){
   "use strict";
 
-  var Counter = function Counter(data){
+  var Counter = function Counter(){
     this.currentI = 0;
-    this.data = data;
   };
 
   Counter.prototype.currentImg = function currentImg() {
@@ -40,9 +39,15 @@ $(function(){
     this.currentI = index;
   };
 
+  Counter.prototype.resetData = function resetData(data) {
+    this.data = data;
+    this.currentI = 0;
+  };
+
   Counter.prototype.incrementCounter = function incrementCounter(num) {
     this.currentI = this.currentI + num;
   };
 
   window.Counter = Counter;
+  window.counter = new Counter();
 });

--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -7,7 +7,7 @@ $(function(){
   var $gifSearchForm = $(".gif_search");
 
   $gifSearchForm.on("ajax:success", function(e, data){
-    window.counter = new Counter(data);
+    window.counter.resetData(data);
     if (!data.length) {
       $resultBox.css("height", "auto");
       $resultBox.html("<p>No Results</p>");

--- a/app/assets/javascripts/image_adder.js
+++ b/app/assets/javascripts/image_adder.js
@@ -1,5 +1,6 @@
 $(function(){
-  var ImageAdder = function(){
+  var ImageAdder = function(counter){
+    this.counter = counter;
     this.$message = $("#page_message");
     this.$useThisButton = $(".use");
     this.$htmlBody = $("html, body");
@@ -8,7 +9,7 @@ $(function(){
 
     function addCurrentImg(e) {
       e.preventDefault();
-      var imageUrl = counter.currentImg();
+      var imageUrl = this.counter.currentImg();
       var newValue = this.$message.val() + addImgShortcut(imageUrl);
       this.$message.val(newValue);
       this.$message.trigger("keyup");
@@ -24,5 +25,5 @@ $(function(){
   };
 
   window.ImageAdder = ImageAdder;
-  window.imageAdder = new ImageAdder();
+  window.imageAdder = new ImageAdder(window.counter);
 });

--- a/app/views/pages/_giphy.html.erb
+++ b/app/views/pages/_giphy.html.erb
@@ -11,7 +11,11 @@
 
   <%= simple_form_for :gif_search, url: "/gif_searches", remote: true do |f| %>
     <div class="giphy-search">
-      <%= f.input :phrase, label: false, input_html: { placeholder: "Search Gif..." } %>
+      <%= f.input(
+        :phrase,
+        label: false,
+        input_html: { placeholder: "Search Gif...", autocomplete: "off" }
+      ) %>
       <%= image_tag("powered_by_giphy.png", class: "logo") %>
     </div>
     <%= f.submit "Search", class: "search" %>

--- a/spec/javascripts/counter_spec.js
+++ b/spec/javascripts/counter_spec.js
@@ -12,7 +12,10 @@ $(function(){
 
     describe("counterStep", function() {
       it("increments the counter", function() {
-        var counter = new Counter(["image0", "image1"]);
+        var counter = new Counter();
+        counter.resetData(["image0", "image1"]);
+
+        expect(counter.currentI).toEqual(0);
 
         counter.counterStep(1);
 
@@ -21,7 +24,8 @@ $(function(){
 
       it("loops back around to zero", function() {
         var data = ["image0", "image1", "image2"];
-        var counter = new Counter(data);
+        var counter = new Counter();
+        counter.resetData(data);
 
         counter.counterStep(1);
         counter.counterStep(1);
@@ -32,7 +36,8 @@ $(function(){
 
       it("allows a negative increment, and loops back around", function() {
         var data = ["image0", "image1", "image2"];
-        var counter = new Counter(data);
+        var counter = new Counter();
+        counter.resetData(data);
 
         expect(counter.currentI).toEqual(0);
 
@@ -45,8 +50,9 @@ $(function(){
     });
 
     describe("currentImg", function() {
-      it("returns the image from the data array indexed at currentI", function() {
-        var counter = new Counter(["image0", "image1"]);
+      it("returns image from the data array indexed at currentI", function(){
+        var counter = new Counter();
+        counter.resetData(["image0", "image1"]);
 
         expect(counter.currentI).toEqual(0);
         expect(counter.currentImg()).toEqual("image0");

--- a/spec/javascripts/image_adder_spec.js
+++ b/spec/javascripts/image_adder_spec.js
@@ -7,22 +7,16 @@ $(function(){
         var $useButton = $("<button class='use'></button>");
         var $pageMessage = $("<textarea id='page_message'></textarea>");
         $("body").append($useButton).append($pageMessage);
-        stubCurrentImg("url.currentImg.gif");
+        var counterStub = {
+          currentImg: function currentImg(){ return "url.currentImg.gif"; }
+        };
 
-        window.imageAdder = new ImageAdder();
+        window.imageAdder = new ImageAdder(counterStub);
         $useButton.trigger("click");
 
         expect($pageMessage.val()).toEqual(" imgkey0 ");
         expect(imageAdder.imageMap[0]).toEqual("url.currentImg.gif");
       });
     });
-
-    function stubCurrentImg(returnVal){
-      window.counter = {
-        currentImg: function currentImg(){
-          return returnVal;
-        }
-      };
-    }
   });
 });


### PR DESCRIPTION
Two separate commits:
The first turns off autocomplete on the gif form to prevent a certain bug when the enter key is used to submit the form.

The second is a pure refactor:
Use dependency injection for imageAdder object
* The imageAdder depends on the counter object to retrieve the
`currentImg`. In order to make this more clear in the code and in tests,
the imageAdder should be instantiated with a counter object passed in.
* This also makes stubbing in test a bit nicer. Instead of stubbing a
property of `window`, a counter stub is used on initialization.

The change:
* Reset data on counter array instead of creating new counter object on
every AJAX response.

Side Effects:
* The downside is that this means a two line setup for most tests to set
the data on the counter.