### PR TITLE
Refactor Gif scrolling logic into objects

### DIFF
--- a/app/assets/javascripts/functions.js
+++ b/app/assets/javascripts/functions.js
@@ -1,3 +1,15 @@
 (function(){
-  window.Functions = {};
+  window.Functions = {
+    insertImgTags: function insertImgTags(message, imageMap) {
+      imageMap.forEach(function(url, index){
+        var key = "imgkey" + index;
+        var imgTag = Functions.buildImgTag(url);
+        message = message.replace(key, imgTag);
+      });
+      return message;
+    },
+    buildImgTag: function buildImgTag(url) {
+      return "<img src='" + url + "'>";
+    }
+  };
 })();

--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -1,51 +1,37 @@
 $(function(){
-  "use strict";
+  var Giphy = function Giphy(counter){
+    this.counter = counter;
+    this.$resultBox = $(".result");
+    this.$stepButton = $(".step");
+    this.$navigation = $(".navigation");
+    this.$gifSearchForm = $(".gif_search");
+    this.$gifSearchForm.on("ajax:success", this.setResultBox.bind(this));
+    this.$stepButton.click(this.takeStep.bind(this));
+  };
 
-  var $resultBox = $(".result");
-  var $stepButton = $(".step");
-  var $navigation = $(".navigation");
-  var $gifSearchForm = $(".gif_search");
-
-  $gifSearchForm.on("ajax:success", function(e, data){
-    window.counter.resetData(data);
-    if (!data.length) {
-      $resultBox.css("height", "auto");
-      $resultBox.html("<p>No Results</p>");
-      $navigation.hide();
-    } else {
-      $resultBox.css("height", 200);
-      $navigation.show();
-      insertCurrentImg();
+  Giphy.prototype = {
+    insertCurrentImg: function insertCurrentImg() {
+      this.$resultBox.html(Functions.buildImgTag(this.counter.currentImg()));
+    },
+    setResultBox: function(e, data) {
+      this.counter.resetData(data);
+      if (!data.length) {
+        this.$resultBox.css("height", "auto");
+        this.$resultBox.html("<p>No Results</p>");
+        this.$navigation.hide();
+      } else {
+        this.$resultBox.css("height", 200);
+        this.$navigation.show();
+        this.insertCurrentImg();
+      }
+    },
+    takeStep: function(e){
+      var increment = parseInt($(e.target).attr("data-value"));
+      this.counter.counterStep(increment);
+      this.insertCurrentImg();
     }
-  });
+  };
 
-  $stepButton.click(function(e){
-    var increment = parseInt($(e.target).attr("data-value"));
-    counter.counterStep(increment);
-    insertCurrentImg();
-  });
-
-  // helpers
-
-  function insertCurrentImg() {
-    $resultBox.html(buildImgTag(counter.currentImg()));
-  }
-
-  // global functions
-
-  function buildImgTag(url) {
-    return "<img src='" + url + "'>";
-  }
-
-  function insertImgTags(message, imageMap) {
-    imageMap.forEach(function(url, index){
-      var key = "imgkey" + index;
-      var imgTag = Functions.buildImgTag(url);
-      message = message.replace(key, imgTag);
-    });
-    return message;
-  }
-
-  window.Functions.buildImgTag = buildImgTag;
-  window.Functions.insertImgTags = insertImgTags;
+  window.Giphy = Giphy;
+  window.giphy = new Giphy(window.counter);
 });

--- a/spec/javascripts/functions_spec.js
+++ b/spec/javascripts/functions_spec.js
@@ -1,0 +1,23 @@
+//= require functions
+
+describe("Functions", function() {
+  describe("insertImgTags", function() {
+    it("replaces keys with image tags", function() {
+      var message = "imgkey0 cat!";
+      var imageMap = ["caturl.gif"];
+
+      var result = Functions.insertImgTags(message, imageMap);
+
+      var finalMessage = "<img src='caturl.gif'> cat!";
+      expect(result).toEqual(finalMessage);
+    });
+
+    it("does not affect a message without image keys", function() {
+      var message = "Hi cat!";
+      var imageMap = ["caturl.gif"];
+
+      var result = Functions.insertImgTags(message, imageMap);
+      expect(result).toEqual(message);
+    });
+  });
+});

--- a/spec/javascripts/giphy_spec.js
+++ b/spec/javascripts/giphy_spec.js
@@ -1,24 +1,38 @@
 //= require giphy
 
-describe("Giphy", function() {
-  describe("insertImgTags", function() {
-    it("replaces keys with image tags", function() {
-      var message = "imgkey0 cat!";
-      var imageMap = ["caturl.gif"];
+$(function(){
+  describe("Giphy", function() {
+    describe("taking a step", function() {
+      // mock the counter Object
+      var CounterMock = function(){
+        this.currentImgCalled = false;
+      };
 
-      var result = Functions.insertImgTags(message, imageMap);
+      CounterMock.prototype = {
+        counterStep: function(increment){
+          this.lastCounterStep = increment;
+        },
+        currentImg: function() {
+          this.currentImgCalled = true;
+        }
+      };
 
-      var finalMessage = "<img src='caturl.gif'> cat!";
-      expect(result).toEqual(finalMessage);
-    });
+      it("calls the counterStep and currentImg methods on counter", function() {
+        var html = $("<div class='navigation'>" +
+            "<button class='use'>Use</button>" +
+            "<button class='step back' data-value='-1'>Back</button>" +
+            "<button class='step next' data-value='1'>Next</button></div>" +
+            "</div>");
+        $("body").append(html);
 
-    it("does not affect a message without image keys", function() {
-      var message = "Hi cat!";
-      var imageMap = ["caturl.gif"];
+        var counterMock = new CounterMock();
+        window.giphy = new window.Giphy(counterMock);
 
-      var result = Functions.insertImgTags(message, imageMap);
+        $(".next").trigger("click"); //data-value 1
 
-      expect(result).toEqual(message);
+        expect(counterMock.lastCounterStep).toEqual(1);
+        expect(counterMock.currentImgCalled).toEqual(true);
+      });
     });
   });
 });


### PR DESCRIPTION
* Implement a functions library for the functions that are somewhat
independent from this new class. These are already tested, but now the
file is renamed.

The new Giphy object communicates with the counter.
* The counter keeps track of current state (GIF img showing). This class
is purposefully decoupled from the DOM. It does not listen for clicks or
change the DOM. It can be told to increment with a direction/amount and
it will return it's state (which GIF image to show) through it's public
api currentImg.
* Giphy asks for the current img and tells the counter class to change
it's state. To test this interaction I thought it would be fun to mock
the counter class without using a mock library like Sinon.
* Other strange things done here include appending html in the test
rather than using a template.

Notes:
* The Giphy class has some distasteful code. It was basically copied and
pasted from a demo on how to use Giphy. It was never satisfactorily
rewritten. This will be tackled later. For now, the bigger OO
restructuring is the focus.