### PR TITLE
Allow Javascript tests to run in the browser

### DIFF
--- a/spec/javascripts/giphy_spec.js
+++ b/spec/javascripts/giphy_spec.js
@@ -9,7 +9,7 @@ $(function(){
             "<button class='step back' data-value='-1'>Back</button>" +
             "<button class='step next' data-value='1'>Next</button></div>" +
             "</div>");
-        $("body").append(html);
+        $("#giphy-page").append(html);
 
         var counterMock = new window.mockHelpers.Counter();
         window.giphy = new window.Giphy(counterMock);

--- a/spec/javascripts/image_adder_spec.js
+++ b/spec/javascripts/image_adder_spec.js
@@ -6,7 +6,7 @@ $(function(){
       it("inserts a placeholder on the page imagekey0", function() {
         var $useButton = $("<button class='use'></button>");
         var $pageMessage = $("<textarea id='page_message'></textarea>");
-        $("body").append($useButton).append($pageMessage);
+        $("#giphy-page").append($useButton).append($pageMessage);
         var counterStub = {
           currentImg: function currentImg(){ return "url.currentImg.gif"; }
         };

--- a/spec/javascripts/preview_spec.js
+++ b/spec/javascripts/preview_spec.js
@@ -6,7 +6,7 @@ $(function(){
       it("displays default text if box is empty", function() {
         var $pageMessage = $("<textarea id='page_message'></textarea>");
         var $previewBox = $("<div class='preview-box'>Default Text!</div>");
-        $("body").append($pageMessage).append($previewBox);
+        $("#giphy-page").append($pageMessage).append($previewBox);
 
         var preview = new Preview();
         preview.createPreview();

--- a/spec/javascripts/support/cleanup.js
+++ b/spec/javascripts/support/cleanup.js
@@ -1,3 +1,7 @@
+beforeEach(function(){
+  $("#giphy-page").remove();
+  $("body").append($("<div id='giphy-page'></div>"));
+});
 afterEach(function() {
-  $("body").html("");
+  $("#giphy-page").html("");
 });


### PR DESCRIPTION
* Teaspoon tests can run in the browser or from the `rake teaspoon`
command line task.
* However, the after hook in `support/cleanup` was clearing the body
element on the page. This meant elements jasmine put in the body were
being wiped clean and causing errors in between tests.
* To solve this a new element is used that teaspoon would not know about
or use. That element can be safely cleared with `$el.html("")` after
each run. The element does need to be removed in a before hook.