### PR TITLE
Refactor imageAdder object

### DIFF
--- a/app/assets/javascripts/image_adder.js
+++ b/app/assets/javascripts/image_adder.js
@@ -1,26 +1,41 @@
 $(function(){
-  var ImageAdder = function(counter){
+  var ImageAdder = function ImageAdder(counter){
     this.counter = counter;
     this.$message = $("#page_message");
     this.$useThisButton = $(".use");
     this.$htmlBody = $("html, body");
-    this.$useThisButton.click(addCurrentImg.bind(this));
+    this.$useThisButton.click(this.addCurrentImg.bind(this));
     this.imageMap = [];
+  };
 
-    function addCurrentImg(e) {
+  ImageAdder.prototype = {
+    addCurrentImg: function addCurrentImg(e) {
       e.preventDefault();
-      var imageUrl = this.counter.currentImg();
-      var newValue = this.$message.val() + addImgShortcut(imageUrl);
-      this.$message.val(newValue);
-      this.$message.trigger("keyup");
+      this.imageMap.push(this._counterCurrentImg());
+      this.$message.val(this._newMessageVal()).trigger("keyup");
+      this.animateScroll();
+    },
+
+    animateScroll: function(){
       this.$htmlBody.animate({
         scrollTop: this.$message.offset().top
       }, 1000);
-    }
+    },
 
-    function addImgShortcut(imageUrl) {
-      imageAdder.imageMap.push(imageUrl);
-      return " imgkey" + (imageAdder.imageMap.length -1) + " ";
+    _lastImgKey: function(){
+      return " imgkey" + (this.imageMap.length -1) + " ";
+    },
+
+    _newMessageVal: function(){
+      return this._currentMessageVal() + this._lastImgKey();
+    },
+
+    _counterCurrentImg: function(){
+      return this.counter.currentImg();
+    },
+
+    _currentMessageVal: function(){
+      return this.$message.val();
     }
   };
 


### PR DESCRIPTION
* This object was hastily scrambled into a constructor object rather
than carefully refactored. This object's main functionality is
reasonably tested so it can be safely refactored.

Changes:

* Use `this` rather than a global reference to the current object
* Use the prototype pattern rather than define functions inside the
constructor.
* Separate pure functions from those with side effects. The underscore
is used to mark methods that should not be public api since they reveal
some kind of internal state that only this object cares about.
* These private functions usually one line. They are also idempotent
since they only need return information about the current state.
The naming is meant to be helpful for determining their purpose and
hiding implementation details.
* In contrast the first two methods (not prefixed with underscores) have
clear side effects. They trigger some external event, mutate state of
the current object (image map) or cause some scrolling on the page.

Future changes:
* I would like to remove the need for that scrolling by hiding the
navigation bar when a GIF is used in the message.