### PR TITLE
Hide GIF scroll buttons after clicking "use"

### DIFF
--- a/app/assets/javascripts/giphy.js
+++ b/app/assets/javascripts/giphy.js
@@ -10,11 +10,14 @@ $(function(){
   };
 
   Giphy.prototype = {
-    insertCurrentImg: function insertCurrentImg() {
-      this.$resultBox.html(Functions.buildImgTag(this.counter.currentImg()));
+    hideNavigation: function(){
+      this.$resultBox.hide();
+      this.$navigation.hide();
     },
+
     setResultBox: function(e, data) {
       this.counter.resetData(data);
+      this.$resultBox.show();
       if (!data.length) {
         this.$resultBox.css("height", "auto");
         this.$resultBox.html("<p>No Results</p>");
@@ -22,13 +25,18 @@ $(function(){
       } else {
         this.$resultBox.css("height", 200);
         this.$navigation.show();
-        this.insertCurrentImg();
+        this._insertCurrentImg();
       }
     },
+
     takeStep: function(e){
       var increment = parseInt($(e.target).attr("data-value"));
       this.counter.counterStep(increment);
-      this.insertCurrentImg();
+      this._insertCurrentImg();
+    },
+
+    _insertCurrentImg: function _insertCurrentImg() {
+      this.$resultBox.html(Functions.buildImgTag(this.counter.currentImg()));
     }
   };
 

--- a/app/assets/javascripts/image_adder.js
+++ b/app/assets/javascripts/image_adder.js
@@ -1,9 +1,9 @@
 $(function(){
-  var ImageAdder = function ImageAdder(counter){
+  var ImageAdder = function ImageAdder(counter, giphy){
     this.counter = counter;
+    this.giphy = giphy;
     this.$message = $("#page_message");
     this.$useThisButton = $(".use");
-    this.$htmlBody = $("html, body");
     this.$useThisButton.click(this.addCurrentImg.bind(this));
     this.imageMap = [];
   };
@@ -13,13 +13,7 @@ $(function(){
       e.preventDefault();
       this.imageMap.push(this._counterCurrentImg());
       this.$message.val(this._newMessageVal()).trigger("keyup");
-      this.animateScroll();
-    },
-
-    animateScroll: function(){
-      this.$htmlBody.animate({
-        scrollTop: this.$message.offset().top
-      }, 1000);
+      this.giphy.hideNavigation();
     },
 
     _lastImgKey: function(){
@@ -40,5 +34,5 @@ $(function(){
   };
 
   window.ImageAdder = ImageAdder;
-  window.imageAdder = new ImageAdder(window.counter);
+  window.imageAdder = new ImageAdder(window.counter, window.giphy);
 });

--- a/spec/javascripts/image_adder_spec.js
+++ b/spec/javascripts/image_adder_spec.js
@@ -10,8 +10,11 @@ $(function(){
         var counterStub = {
           currentImg: function currentImg(){ return "url.currentImg.gif"; }
         };
+        var giphyStub = {
+          hideNavigation: function(){ }
+        };
 
-        window.imageAdder = new ImageAdder(counterStub);
+        var imageAdder = new ImageAdder(counterStub, giphyStub);
         $useButton.trigger("click");
 
         expect($pageMessage.val()).toEqual(" imgkey0 ");


### PR DESCRIPTION
* When the user choses a GIF the navigation bar with 3 buttons and GIF
itself should be hidden. That way the user can focus on the message
preview (where the GIF will soon appear). Otherwise the page appears too
cluttered.
* This eliminates the need for the animated scrolling.

Implementation:
* The image adder tells the giphy object to hide the navigation. The
object named Giphy is what controls the interaction with the GIF search
form and navigation. This keeps the "adding the image url to the
message" logic separate.

* The ImageAdder test uses stubbing rather than mocking for the moment
even though a nice counter mock is available. I kind of like the
variety, but I should probably stick with one eventually. Using stubbing
and state verification was nice here previously since one could see how
the whole system is supposed to work (i.e. the currentImg url from the
counter object gets pushed into the imageAdder's array of images).
Mocking might be nicer for testing that the imageAdder actually tells
giphy to hide navigation.