### PR TITLE
Users can copy a link to clipboard with one click

### DIFF
--- a/.javascript-style.json
+++ b/.javascript-style.json
@@ -17,6 +17,7 @@
     "jQuery",
     "jasmine",
     "beforeEach",
+    "Clipboard",
     "describe",
     "expect",
     "it",

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "attr_encrypted"
 
 gem "bourbon", "~> 4.2.0"
 gem "bcrypt"
+gem "clipboard-rails"
 gem "browser"
 gem "coffee-rails", "~> 4.1.0"
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       capybara (>= 2.3.0, < 2.8.0)
       json
     chronic (0.10.2)
+    clipboard-rails (1.5.15)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -351,6 +352,7 @@ DEPENDENCIES
   capistrano-rbenv
   capybara-screenshot
   capybara-webkit
+  clipboard-rails
   coffee-rails (~> 4.1.0)
   database_cleaner
   delayed_job_active_record

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,5 @@
 //= require search_input
 //= require image_adder
 //= require insert_image_tags
+//= require clipboard
+//= require initialize_clipboard

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "rebuild_base";
 @import "pages/page";
 @import "pages/giphy";
+@import "pages/success";

--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -12,7 +12,6 @@ button {
   font-size: $base-font-size;
   font-weight: 600;
   line-height: 1;
-  margin: 10px 0;
   padding: 0.75em 1em;
   text-decoration: none;
   user-select: none;
@@ -31,4 +30,10 @@ button {
   }
 
   width: 48%;
+}
+
+button,
+input,
+textarea {
+  margin: 10px 0 0;
 }

--- a/app/assets/stylesheets/pages/success.scss
+++ b/app/assets/stylesheets/pages/success.scss
@@ -1,0 +1,15 @@
+.copy-block {
+  margin-bottom: 20px;
+
+  @media screen and (min-width: 768px) {
+    @include outer-container;
+
+    button {
+      @include span-columns(2);
+    }
+
+    input {
+      @include span-columns(10);
+    }
+  }
+}

--- a/app/assets/stylesheets/rebuild_base.scss
+++ b/app/assets/stylesheets/rebuild_base.scss
@@ -1,5 +1,6 @@
 body {
   @include outer-container;
+  margin-top: 20px;
   width: 90%;
 
   @media screen and (min-width: 768px) {

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -10,6 +10,10 @@ class PagePresenter < SimpleDelegator
     end
   end
 
+  def to_param
+    url_key
+  end
+
   private
 
   def optional_fields_errors?

--- a/app/views/pages/success.html.erb
+++ b/app/views/pages/success.html.erb
@@ -1,10 +1,13 @@
-<p>Your secret page is available at:</p>
-<p><b><%= root_url + @page.url_key %></b></p>
-<p>Copy, paste and send to a friend</p>
+<h1>Your onetime note:</h1>
 
-<p>To view and destroy your own page click
+<div class="copy-block">
+  <button class="copy" data-clipboard-target="#copy-text">Copy Link</button>
+  <input id="copy-text" value="<%= page_url(@page) %>">
+</div>
+
+<p>To view and destroy this page click
   <%= link_to(
     "here",
-    root_url + @page.url_key
+    page_url(@page)
   ) %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "pages#new"
   resources :secrets, as: :pages, controller: :pages, only: [:new, :create]
-  get "/:url_key" => "permissions#new"
+  get "/:url_key" => "permissions#new", as: :page
   resources :permissions, only: [:create]
   resources :previews, only: [:create]
 

--- a/spec/features/create_a_secret_spec.rb
+++ b/spec/features/create_a_secret_spec.rb
@@ -9,9 +9,10 @@ feature "Visitor Creates a Secret" do
 
     click_button "Create"
 
-    expect(page).to have_content("example")
+    expect(page).to have_field("copy-text", with: page_url("example"))
 
     click_link("here")
+
     expect(page).to have_text("Stop Rebulba!")
     expect(Page.count).to eq(0)
   end
@@ -25,7 +26,7 @@ feature "Visitor Creates a Secret" do
 
     click_button "Create"
 
-    expect(page).to have_content("example")
+    expect(page).to have_field("copy-text", with: page_url("example"))
 
     click_link("here")
     fill_in "Password", with: "Password"

--- a/spec/javascripts/initialize_clipboard.js
+++ b/spec/javascripts/initialize_clipboard.js
@@ -1,0 +1,3 @@
+$(function(){
+  new Clipboard(".copy");
+});


### PR DESCRIPTION
* Using the `clipboard-rails` gem that wraps
https://github.com/zenorocha/clipboard.js it is easy to copy text to the
clipboard with most modern browsers
* The success page is restyled to incorporate this button. It looks a
lot better now.

* Adding a route helper so that `page_path` or `page_url` can be used in
the view file instead of concatenating strings. Some tests could also be
amended later because of this. I defined the `to_param` method on the
presenter rather than the page model itself. This keeps
view/presentation logic separate from persistence (rails uses to_param
to build the path to a resource. If this is not defined, id is the
default).

* The margin around buttons, textarea, inputs should be the same.
* Add margin on top of the body class for better look.

Mobile before change:
<img width="157" alt="screen shot 2016-12-04 at 2 42 00 pm" src="https://cloud.githubusercontent.com/assets/6473009/20868715/063b5168-ba30-11e6-9b08-58780453c929.png">
Desktop before change:
<img width="1178" alt="screen shot 2016-12-04 at 2 41 38 pm" src="https://cloud.githubusercontent.com/assets/6473009/20868716/063b7300-ba30-11e6-92d9-ddf8fbc0add1.png">

Mobile after change:
<img width="152" alt="screen shot 2016-12-04 at 2 40 56 pm" src="https://cloud.githubusercontent.com/assets/6473009/20868718/0675c3d4-ba30-11e6-94e7-4ae5282f892f.png">
Desktop after change:
<img width="1188" alt="screen shot 2016-12-04 at 2 41 07 pm" src="https://cloud.githubusercontent.com/assets/6473009/20868717/0648b79a-ba30-11e6-94d2-3b9b93bf5134.png">


