### PR TITLE
The height of inputs and buttons should match

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -12,7 +12,6 @@ button {
   font-size: $base-font-size;
   font-weight: 600;
   line-height: 1;
-  padding: 0.75em 1em;
   text-decoration: none;
   user-select: none;
   vertical-align: middle;
@@ -36,4 +35,5 @@ button,
 input,
 textarea {
   margin: 10px 0 0;
+  padding: 10px 16px;
 }


### PR DESCRIPTION
* The copy link puts a button next to an input so the difference in
height can be seen. This is fixed with a small adjustment to padding.
Padding is now hard coded for buttons rather than being relative to
line-height (em units). The relative size unit is useful only if both
input and buttons follow the rule (could chnage that later).