### PR TITLE
UI improvements for copying and previewing

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -16,6 +16,7 @@ select {
 label {
   font-weight: 600;
   margin-bottom: $small-spacing / 2;
+  overflow-wrap: break-word;
 
   &.required::after {
     content: "*";

--- a/app/views/pages/success.html.erb
+++ b/app/views/pages/success.html.erb
@@ -1,13 +1,10 @@
 <h1>Your onetime note:</h1>
 
-<div class="copy-block">
-  <button class="copy" data-clipboard-target="#copy-text">Copy Link</button>
+<div class="copy-block copy" data-clipboard-target="#copy-text">
+  <button>Copy Link</button>
   <input id="copy-text" value="<%= page_url(@page) %>">
 </div>
 
-<p>To view and destroy this page click
-  <%= link_to(
-    "here",
-    page_url(@page)
-  ) %>
+<p>
+  To view and destroy this page click <%= link_to("here", page_url(@page)) %>
 </p>


### PR DESCRIPTION


* Allow clicking input element to copy note link

Text for long url_key should wrap to next line:
* This text was overflowing out of the container off to the side of the
page. This was not attractive so instead it will wrap now.
<img width="307" alt="screen shot 2016-12-10 at 2 47 39 pm" src="https://cloud.githubusercontent.com/assets/6473009/21075928/a7a4320c-beec-11e6-8f39-e2038b46baf0.png">