### PR TITLE
Fix spacing on optional fields (buttons/inputs)

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -34,6 +34,5 @@ button {
 button,
 input,
 textarea {
-  margin: 10px 0 0;
   padding: 10px 16px;
 }

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -15,7 +15,6 @@ select {
 
 label {
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
   overflow-wrap: break-word;
 
   &.required::after {

--- a/app/assets/stylesheets/pages/giphy.scss
+++ b/app/assets/stylesheets/pages/giphy.scss
@@ -8,9 +8,6 @@
     button {
       @include span-columns(4);
     }
-
-    .use {
-    }
   }
 
   .giphy-search {

--- a/app/assets/stylesheets/pages/page.scss
+++ b/app/assets/stylesheets/pages/page.scss
@@ -1,17 +1,30 @@
-.error {
-  color: $red;
-}
+#giphy-page {
+  .error {
+    color: $red;
+  }
 
-.hidden {
-  display: none;
-}
+  .hidden {
+    display: none;
+  }
 
-.preview-box {
-  border: 1px dashed $black;
-  margin-top: 5px;
-  padding: 10px;
-}
+  .preview-box {
+    border: 1px dashed $black;
+    margin-top: 5px;
+    padding: 10px;
+  }
 
-#more-options {
-  float: right;
+  #more-options {
+    float: right;
+  }
+
+  .optional-fields {
+    .input {
+      margin-top: $small-spacing;
+    }
+  }
+
+  button,
+  [type="submit"] {
+    margin: $small-spacing 0;
+  }
 }


### PR DESCRIPTION
* It was hard to tell which labels went with which inputs in the
optional fields. This was resolved by grouping the two closer together.
This meant spacing (via the margins) had to be pulled out and
consolidated.

before:
<img width="741" alt="screen shot 2016-12-10 at 6 09 56 pm" src="https://cloud.githubusercontent.com/assets/6473009/21076830/fa99502a-bf03-11e6-8cca-2b661d7987f6.png">

after
<img width="776" alt="screen shot 2016-12-10 at 6 10 10 pm" src="https://cloud.githubusercontent.com/assets/6473009/21076829/f2b6d77e-bf03-11e6-96d5-fc589e7b9463.png">
