### PR TITLE
Lower opacity in preview image while typing

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -23,6 +23,10 @@ $(function(){
     },
     displayMessage: function(text){
       this.$previewBox.html(text);
+      this.$previewBox.css("opacity", 1);
+    },
+    loading: function() {
+      this.$previewBox.css("opacity", 0.3);
     }
   };
 

--- a/app/assets/javascripts/preview_timer.js
+++ b/app/assets/javascripts/preview_timer.js
@@ -14,6 +14,7 @@ $(function(){
   };
 
   $message.keyup(function(){
+    window.preview.loading();
     delay(preview, 1000);
   });
 });


### PR DESCRIPTION
* This gives the users some feedback to let them know a preview is being
generated. Since the preview must be fetched from the server, it will be
a while before the preview updates. Since the preview is only fetched
after a delay between keyup events, the time for a preview can feel
lengthy.
* This dims the preview until the callback to update finishes.

![d53832005c8a185b4c911fc919daa173](https://cloud.githubusercontent.com/assets/6473009/24074369/a433692e-0bdd-11e7-96a3-c9e88ce86988.gif)
