### PR TITLE
Make redirecting after several seconds optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@
   * The url for the note can be set to make it feel more personal: e.g.
     `https://onetimenote.com/happy-birthday-bob`
     Otherwise a random string is generated and used.
-  * The browser will navigate away from the note 10 seconds after it has been
-    viewed. The timing here can be specified between 1 and 10 seconds.
+  * The browser can navigate away from the note several seconds after it has
+    been viewed. This is disabled by default, but it can be set between 1 and 10
+    seconds
   * No password is required if this field is left blank.
 
 ## Expiration

--- a/app/assets/javascripts/clear_location.js
+++ b/app/assets/javascripts/clear_location.js
@@ -1,5 +1,3 @@
-window.history.pushState("", "", "/" + page.url_key);
-
 document.addEventListener("DOMContentLoaded", function(event) {
   var redirect = function() {
     window.history.pushState("", "", "/");

--- a/app/assets/javascripts/toggle_options.js
+++ b/app/assets/javascripts/toggle_options.js
@@ -1,9 +1,13 @@
 $(function(){
   var $button = $("#more-options");
   var $optionalFieldWrap = $(".optional-fields");
-
-  $button.click(function(e){
-    e.preventDefault();
+  $button.click(function(){
     $optionalFieldWrap.toggle("hidden");
+  });
+
+  var $redirect = $("#page_redirect");
+  var $duration = $(".page_duration");
+  $redirect.click(function(){
+    $duration.toggle("hidden");
   });
 });

--- a/app/assets/stylesheets/pages/page.scss
+++ b/app/assets/stylesheets/pages/page.scss
@@ -27,4 +27,10 @@
   [type="submit"] {
     margin: $small-spacing 0;
   }
+
+  #new_page {
+    .btn {
+      float: left;
+    }
+  }
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,6 +18,7 @@ class PagesController < ApplicationController
       :duration,
       :message,
       :password,
+      :redirect,
       :url_key
     )
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -8,7 +8,8 @@ class Page < ActiveRecord::Base
   validates_uniqueness_of :url_key
   validates(
     :duration,
-    inclusion: { in: (1..10), message: "Must be between 1 and 10 seconds" }
+    inclusion: { in: (1..10), message: "Must be between 1 and 10 seconds" },
+    if: :redirect?
   )
 
   after_initialize :set_random_url_key

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -10,11 +10,23 @@ class PagePresenter < SimpleDelegator
     end
   end
 
+  def duration_state
+    if duration_error?
+      ""
+    else
+      "hidden"
+    end
+  end
+
   def to_param
     url_key
   end
 
   private
+
+  def duration_error?
+    errors.include?(:duration)
+  end
 
   def optional_fields_errors?
     errors.any? { |field| OPTIONAL_FIELDS.include?(field) }

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -14,7 +14,6 @@
   </div>
 
   <div class="optional-fields <%= @page.optional_fields_state %>">
-    <%= f.input :duration, input_html: { value: 7, max: 10, min: 1 } %>
     <%= f.input(
       :url_key,
       as: :string,
@@ -22,9 +21,15 @@
       label: "Specify url: #{page_url(@page)}"
     ) %>
     <%= f.input :password %>
+    <%= f.input :redirect, label: "Vanish after several seconds" %>
+    <%= f.input(
+      :duration,
+      input_html: { value: 7, max: 10, min: 1 },
+      wrapper_html: { class: @page.duration_state }
+    ) %>
   </div>
 
   <%= f.button :submit, "Create Note" %>
-  <button id="more-options">More Options</button>
 <% end %>
 
+<button id="more-options">More Options</button>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -3,5 +3,6 @@
 </div>
 <script>
   window.page = <%= { url_key: @page.url_key, duration: (@page.duration * 1000) }.to_json.html_safe %>;
+  window.history.pushState("", "", "/" + page.url_key);
 </script>
-<%= javascript_include_tag "clear_location" %>
+<%= javascript_include_tag "clear_location" if @page.redirect? %>

--- a/db/migrate/20170722190439_add_redirect_to_pages.rb
+++ b/db/migrate/20170722190439_add_redirect_to_pages.rb
@@ -1,0 +1,5 @@
+class AddRedirectToPages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pages, :redirect, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160828133604) do
+ActiveRecord::Schema.define(version: 20170722190439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +18,12 @@ ActiveRecord::Schema.define(version: 20160828133604) do
   create_table "pages", force: :cascade do |t|
     t.string   "url_key"
     t.string   "password_digest"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.integer  "duration"
     t.text     "encrypted_message"
     t.text     "encrypted_message_iv"
+    t.boolean  "redirect",             default: false
   end
 
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -16,11 +16,17 @@ describe Page do
   end
 
   describe "duration" do
-    it "cannot be outside the range of 1 and 10" do
-      page = build(:page, duration: 11)
+    it "cannot be outside the range of 1 and 10 if set to redirect" do
+      page = build(:page, duration: 11, redirect: true)
 
       expect(page).to_not be_valid
       expect(page.errors[:duration]).to be_present
+    end
+
+    it "ignores duration validation if redirect is set to false" do
+      page = build(:page, duration: 999, redirect: false)
+
+      expect(page).to be_valid
     end
 
     it "rounds to an integer" do


### PR DESCRIPTION
* By default pages would always redirect after 1-10 seconds.
Unfortunately, this limits the use of this website. Sending information
that the receiver wishes to copy and paste required quick copy/paste
skills.

* A redirect column is added to pages which determines whether the page
will include the Javascript that causes a redirect.

*** Challenges ***
* The stateful toggling functionality was already solved. When the
duration has errors, one would like that to not be hidden so the user
can see the errors. This leverages the presenter that was introduced to
toggle the optional fields.
* The preventDefault was being used to prevent the form submitting when
the "More Options" button was pressed. This button did not need to be
inside the form. It was removed, and then the previous button was
floated left to allow the two to appear next to each other.


<img width="580" alt="screen shot 2017-07-22 at 4 27 43 pm" src="https://user-images.githubusercontent.com/6473009/28494386-c1be765c-6efa-11e7-82f2-47576ceda869.png">
<img width="585" alt="screen shot 2017-07-22 at 4 27 52 pm" src="https://user-images.githubusercontent.com/6473009/28494385-c1b96cb6-6efa-11e7-8423-40ac65cf9748.png">