### PR TITLE
Users can set expiration date on pages

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -27,7 +27,11 @@ button {
     cursor: not-allowed;
     opacity: 0.5;
   }
+}
 
+#{$all-button-inputs},
+button,
+select {
   width: 48%;
 }
 

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -72,6 +72,5 @@ input[type="file"] {
 
 select {
   margin-bottom: $base-spacing;
-  max-width: 100%;
-  width: auto;
+  width: 100%;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,10 +16,14 @@ class PagesController < ApplicationController
   def page_params
     params.require(:page).permit(
       :duration,
+      :expires_at,
       :message,
       :password,
       :redirect,
       :url_key
-    )
+    ).tap do |attributes|
+      attributes["expires_at"] =
+        Expiration.translate(attributes["expires_at"])
+    end
   end
 end

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -2,7 +2,7 @@ require "browser"
 
 class PermissionsController < ApplicationController
   def new
-    @page = Page.find_by!(url_key: params[:url_key])
+    @page = Page.unexpired.find_by!(url_key: params[:url_key])
 
     if @page.password_digest
       render "new"
@@ -14,7 +14,7 @@ class PermissionsController < ApplicationController
   end
 
   def create
-    @page = Page.find_by(url_key: url_key)
+    @page = Page.unexpired.find_by(url_key: url_key)
     permission = Permission.new(@page)
     if permission.grant_for?(page_password)
       @page.password = page_password

--- a/app/models/expiration.rb
+++ b/app/models/expiration.rb
@@ -1,0 +1,14 @@
+class Expiration
+  DEFAULT = "30 days".freeze
+  EXPIRES_AT = {
+    "5 minutes" => 5.minutes.from_now,
+    "1 hour" => 1.hour.from_now,
+    "1 day" => 1.day.from_now,
+    "1 week" => 1.week.from_now,
+    "30 days" => 30.days.from_now
+  }.freeze
+
+  def self.translate(text)
+    EXPIRES_AT[(text || DEFAULT)]
+  end
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,6 +3,8 @@ class Page < ActiveRecord::Base
 
   has_secure_password validations: false
 
+  scope :unexpired, -> { where("pages.expires_at >= ?", Time.zone.now) }
+
   validates :url_key, presence: true
   validates :message, presence: true
   validates_uniqueness_of :url_key

--- a/app/models/page_pruner.rb
+++ b/app/models/page_pruner.rb
@@ -3,5 +3,9 @@ class PagePruner
     def prune_unseen
       Page.where("created_at < ?", 30.days.ago).destroy_all
     end
+
+    def prune_expired
+      Page.where("expires_at < ?", Time.zone.now).destroy_all
+    end
   end
 end

--- a/app/presenters/page_presenter.rb
+++ b/app/presenters/page_presenter.rb
@@ -2,6 +2,10 @@
 class PagePresenter < SimpleDelegator
   OPTIONAL_FIELDS = [:url_key, :password, :duration].freeze
 
+  def expires_at_options
+    Expiration::EXPIRES_AT.keys
+  end
+
   def optional_fields_state
     if optional_fields_errors?
       ""

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -21,6 +21,11 @@
       label: "Specify url: #{page_url(@page)}"
     ) %>
     <%= f.input :password %>
+    <%= f.input(
+      :expires_at,
+      collection: @page.expires_at_options,
+      selected: Expiration::DEFAULT
+    ) %>
     <%= f.input :redirect, label: "Vanish after several seconds" %>
     <%= f.input(
       :duration,

--- a/db/migrate/20170723204042_add_expires_at_to_pages.rb
+++ b/db/migrate/20170723204042_add_expires_at_to_pages.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToPages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pages, :expires_at, :datetime, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170722190439) do
+ActiveRecord::Schema.define(version: 20170723204042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20170722190439) do
     t.text     "encrypted_message"
     t.text     "encrypted_message_iv"
     t.boolean  "redirect",             default: false
+    t.datetime "expires_at"
   end
 
 end

--- a/lib/tasks/pages.rake
+++ b/lib/tasks/pages.rake
@@ -2,5 +2,6 @@ namespace "pages" do
   desc "prune unseen pages"
   task prune_unseen: :environment do
     PagePruner.prune_unseen
+    PagePruner.prune_expired
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     password "Password"
     duration 3
     message "Defeat Rebulba"
+    expires_at 1.week.from_now
   end
 end

--- a/spec/models/expiration_spec.rb
+++ b/spec/models/expiration_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Expiration do
+  describe ".translate" do
+    it "translates string text to datetime" do
+      Timecop.freeze do
+        one_hour_later = Time.zone.now + 1.hour
+
+        translated_time = Expiration.translate("1 hour")
+
+        expect(translated_time.hour).to eq(one_hour_later.hour)
+      end
+    end
+
+    it "uses 30 days as a default if input is nil" do
+      Timecop.freeze do
+        translated_time = Expiration.translate(nil)
+
+        expect(translated_time.to_date).to eq(30.days.from_now.to_date)
+      end
+    end
+  end
+end

--- a/spec/models/page_pruner_spec.rb
+++ b/spec/models/page_pruner_spec.rb
@@ -5,16 +5,30 @@ describe "PagePruner" do
   describe ".prune_unseen" do
     it "destroys pages over 30 days old" do
       Timecop.freeze do
-        Timecop.travel(31.days.ago)
-        old_page = create(:page)
+        old_page = create(:page, created_at: 40.days.ago)
 
-        Timecop.return
-        current_page = create(:page)
+        current_page = create(:page, created_at: 5.days.ago)
 
         PagePruner.prune_unseen
 
         expect(Page.find_by_id(current_page.id)).to be_present
         expect(Page.find_by_id(old_page.id)).to be_blank
+      end
+    end
+
+    describe ".prune_expired" do
+      it "destroys expired pages only" do
+        Timecop.freeze do
+          expired = create(:page, expires_at: 5.minutes.ago)
+          unexpired = create(:page, expires_at: 5.minutes.from_now)
+          no_expiration = create(:page, expires_at: nil)
+
+          PagePruner.prune_expired
+
+          expect(Page.find_by_id(unexpired.id)).to be_present
+          expect(Page.find_by_id(no_expiration.id)).to be_present
+          expect(Page.find_by_id(expired.id)).to be_blank
+        end
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 describe Page do
+  describe ".unexpired" do
+    it "does not allow expired pages to be viewed" do
+      _expired_page = create(:page, expires_at: 10.minutes.ago)
+      unexpired_page = create(:page, expires_at: 5.days.from_now)
+
+      expect(Page.unexpired).to eq([unexpired_page])
+    end
+  end
+
   it "validates uniqueness of url_key" do
     page = create(:page, url_key: "AA", password: nil)
 


### PR DESCRIPTION
* Users can choose from a list of expiration date/times for the page
they create: e.g. 5 minutes, 1 hour, 30 days, etc.

![img_0257](https://user-images.githubusercontent.com/6473009/31056742-e4ec2570-a6a4-11e7-8f81-05dbb8146a64.PNG)

***Why?***
* This will make page expiration more explicit. Currently pages expire
after 30 days, but users are not informed of this.
* This is also a nice feature if information is time sensitive, or
if someone wants extra security (one could accidentally create a page
and lose the link).

***How does this work?***
* A select field is added with options for the different dates. The
default, 30 days is how long pages lasted previously. Since this is the
default value, this extra option can be hidden until a user selects
"Options". This keeps creating a note from taking too long.
* Previously pages were deleted after 30 days by a cron job. Now that
cron will look for pages past their expiration date.
* A scope `unexpired` is added since pages can only be looked at if they
have not expired. The `Expiration` object that translates form input
into actual date/times ensures we don't need to deal with time zones.
The server will translate this value at the time the form is posted, and
it will presumably use the same time zone when querying for `unexpired`
notes.

***Indexing***
* expires_at has an index to make pruning for expired pages easier (this
website gets tons of traffic). The important operation involves finding
the note to show a user, but only the index on url_key is needed since
since this has the highest cardinality possible-- each one is unique).
That is why we don't opt for a compound index here.

***What's next?***
* The next step is to enforce data integrity with a column default on
`pages.expires_at`. This could not be added now since it would prevent
previously created pages from being viewed. That will be fixed with
a data migration (set those pages to expire in 30 days).
