### PR TITLE
Prevent notes from being deleted before expiration

### DIFF
--- a/app/models/expiration.rb
+++ b/app/models/expiration.rb
@@ -1,14 +1,20 @@
 class Expiration
   DEFAULT = "30 days".freeze
-  EXPIRES_AT = {
-    "5 minutes" => 5.minutes.from_now,
-    "1 hour" => 1.hour.from_now,
-    "1 day" => 1.day.from_now,
-    "1 week" => 1.week.from_now,
-    "30 days" => 30.days.from_now
-  }.freeze
+  class << self
+    def translate(text)
+      expires_at[(text || DEFAULT)]
+    end
 
-  def self.translate(text)
-    EXPIRES_AT[(text || DEFAULT)]
+    private
+
+    def expires_at
+      {
+        "5 minutes" => 5.minutes.from_now,
+        "1 hour" => 1.hour.from_now,
+        "1 day" => 1.day.from_now,
+        "1 week" => 1.week.from_now,
+        "30 days" => 30.days.from_now
+      }.freeze
+    end
   end
 end


### PR DESCRIPTION
***Why?***
* Notes are being erroneously deleted because the hash constant in
Expiration is frozen in time. The first time the class was loaded (on
deploy) the times were set. New notes are created with those old times
used as their expiration_at.

***How does this fix it?***
* This hash needs to be dynamically created each time the user input is
translated into a time.
* Timecop seems to be giving me trouble so I am not testing this one.