### PR TITLE
Allow pages to be viewed multiple times

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,6 +18,7 @@ class PagesController < ApplicationController
       :duration,
       :expires_at,
       :message,
+      :multiview,
       :password,
       :redirect,
       :url_key

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -39,7 +39,7 @@ class PermissionsController < ApplicationController
   end
 
   def reveal(page)
-    page.destroy!
+    page.view!
     render "pages/show"
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -24,6 +24,10 @@ class Page < ActiveRecord::Base
     end
   end
 
+  def view!
+    destroy! unless multiview?
+  end
+
   private
 
   def padded_or_chopped(password)

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -27,6 +27,7 @@
       selected: Expiration::DEFAULT
     ) %>
     <%= f.input :redirect, label: "Vanish after several seconds" %>
+    <%= f.input :multiview, label: "Allow page to be viewed multiple times" %>
     <%= f.input(
       :duration,
       input_html: { value: 7, max: 10, min: 1 },

--- a/db/migrate/20181014152904_add_multiview_to_pages.rb
+++ b/db/migrate/20181014152904_add_multiview_to_pages.rb
@@ -1,0 +1,5 @@
+class AddMultiviewToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :multiview, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170723204042) do
+ActiveRecord::Schema.define(version: 2018_10_14_152904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "pages", force: :cascade do |t|
-    t.string   "url_key"
-    t.string   "password_digest"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.integer  "duration"
-    t.text     "encrypted_message"
-    t.text     "encrypted_message_iv"
-    t.boolean  "redirect",             default: false
+  create_table "pages", id: :serial, force: :cascade do |t|
+    t.string "url_key"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "duration"
+    t.text "encrypted_message"
+    t.text "encrypted_message_iv"
+    t.boolean "redirect", default: false
     t.datetime "expires_at"
+    t.boolean "multiview", default: false
   end
 
 end

--- a/spec/features/multiview_page_spec.rb
+++ b/spec/features/multiview_page_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+feature "create and view a multiview page" do
+  scenario "visit a page twice" do
+    visit new_page_path
+    fill_in "page_url_key", with: "example"
+    fill_in "page_message", with: "Stop Rebulba!"
+    check "page_multiview"
+
+    click_button "Create"
+
+    visit page_path("example")
+
+    expect(page).to have_text("Stop Rebulba!")
+
+    visit page_path("example")
+
+    expect(page).to have_text("Stop Rebulba!")
+  end
+
+  scenario "with password" do
+    visit new_page_path
+    fill_in "page_url_key", with: "example"
+    fill_in "page_message", with: "Stop Rebulba!"
+    check "page_multiview"
+    fill_in "page_password", with: "password"
+
+    click_button "Create"
+
+    visit page_path("example")
+    fill_in "Password", with: "password"
+    click_button "Submit"
+
+    expect(page).to have_text("Stop Rebulba!")
+
+    visit page_path("example")
+    fill_in "Password", with: "password"
+    click_button "Submit"
+
+    expect(page).to have_text("Stop Rebulba!")
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -44,4 +44,22 @@ describe Page do
       expect(page.duration).to eq(1)
     end
   end
+
+  describe "#view!" do
+    it "destroys a non multiview page" do
+      page = create(:page, multiview: false)
+
+      page.view!
+
+      expect(Page.find_by_id(page.id)).to be_nil
+    end
+
+    it "destroys a multiview page" do
+      page = create(:page, multiview: true)
+
+      page.view!
+
+      expect(Page.find_by_id(page.id)).to eq(page)
+    end
+  end
 end


### PR DESCRIPTION
***If one wishes to post a vanishing to note to a group***
* This allows a page to be viewed multiple times. The pages expiration
controls when it is not visible. So a page set to expire in five minutes
could be viewed by multiple people (e.g. in a group text thread or slack
channel) before vanishing.

***Follow up***
* This could be a default option
* The timing options may need to change (30 seconds could be an option
even though that is pushing it with a free Heroku tier)
* Perhaps more instructions could be added here too.
* write a cron task to destroy the expired pages.

***Details***
* Instead of calling page.destroy! from the controller there is a new
`page#view!` method that decides whether to destroy the page. If the
boolean field `multiview` was set to `true` when the page was created
then the page will not be destroyed.
* The `unexpired` scope now prevents these pages from being destroyed.
* The cron tasks that used to destroy pages do not run on Heroku (this
was originally on digital ocean). This means the pages will sit around
for now.